### PR TITLE
Feature/no ref/kubeadm join anonymous auth false

### DIFF
--- a/kubespray/roles/kubernetes/kubeadm/defaults/main.yml
+++ b/kubespray/roles/kubernetes/kubeadm/defaults/main.yml
@@ -10,3 +10,8 @@ kube_override_hostname: >-
   {%- else -%}
   {{ inventory_hostname }}
   {%- endif -%}
+
+# discovery_type: token(default) or file
+discovery_type: token
+discovery_file: "/tmp/discovery.yml"
+admin_conf: "/etc/kubernetes/admin.conf"

--- a/kubespray/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/kubespray/roles/kubernetes/kubeadm/tasks/main.yml
@@ -10,6 +10,23 @@
   tags:
     - facts
 
+- name: get admin.conf
+  ansible.builtin.slurp:
+    src: "{{ admin_conf }}"
+  register: admin_conf_str
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  run_once: true
+
+- name: copy admin.conf to the node.
+  ansible.builtin.copy:
+    dest: "{{ discovery_file }}"
+    content: "{{ admin_conf_str.content|b64decode|replace('127.0.0.1', hostvars[groups['kube_control_plane'][0]].ip) }}"
+  when: discovery_type == 'file'
+
+- name: pause for debugging
+  ansible.builtin.pause:
+    prompt: "Enter to continue"
+  
 - name: Check if kubelet.conf exists
   stat:
     path: "{{ kube_config_dir }}/kubelet.conf"
@@ -85,7 +102,7 @@
   when: not is_kube_master and (not kubelet_conf.stat.exists)
   block:
 
-    - name: Join to cluster
+    - name: Join to cluster using token-based discovery
       command: >-
         timeout -k {{ kubeadm_join_timeout }} {{ kubeadm_join_timeout }}
         {{ bin_dir }}/kubeadm join
@@ -94,10 +111,21 @@
         --skip-phases={{ kubeadm_join_phases_skip | join(',') }}
       register: kubeadm_join
       changed_when: kubeadm_join is success
+      when: discovery_type == 'token'
+    - name: Join to cluster using file-based discovery
+      command: >-
+        timeout -k {{ kubeadm_join_timeout }} {{ kubeadm_join_timeout }}
+        {{ bin_dir }}/kubeadm join
+        --discovery-file {{ discovery_file }}
+        --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests
+        --skip-phases={{ kubeadm_join_phases_skip | join(',') }}
+      register: kubeadm_join
+      changed_when: kubeadm_join is success
+      when: discovery_type == 'file'
 
   rescue:
 
-    - name: Join to cluster with ignores
+    - name: Join to cluster with ignores using token-based discovery
       command: >-
         timeout -k {{ kubeadm_join_timeout }} {{ kubeadm_join_timeout }}
         {{ bin_dir }}/kubeadm join
@@ -106,6 +134,17 @@
         --skip-phases={{ kubeadm_join_phases_skip | join(',') }}
       register: kubeadm_join
       changed_when: kubeadm_join is success
+      when: discovery_type == 'token'
+    - name: Join to cluster with ignores using file-based discovery
+      command: >-
+        timeout -k {{ kubeadm_join_timeout }} {{ kubeadm_join_timeout }}
+        {{ bin_dir }}/kubeadm join
+        --discovery-file {{ discovery_file }}
+        --ignore-preflight-errors=all
+        --skip-phases={{ kubeadm_join_phases_skip | join(',') }}
+      register: kubeadm_join
+      changed_when: kubeadm_join is success
+      when: discovery_type == 'file'
 
   always:
 

--- a/kubespray/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/kubespray/roles/kubernetes/kubeadm/tasks/main.yml
@@ -10,23 +10,19 @@
   tags:
     - facts
 
-- name: get admin.conf
+- name: Get admin.conf
   ansible.builtin.slurp:
     src: "{{ admin_conf }}"
   register: admin_conf_str
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   run_once: true
 
-- name: copy admin.conf to the node.
+- name: Create discovery file from admin.conf
   ansible.builtin.copy:
     dest: "{{ discovery_file }}"
     content: "{{ admin_conf_str.content|b64decode|replace('127.0.0.1', hostvars[groups['kube_control_plane'][0]].ip) }}"
   when: discovery_type == 'file'
 
-- name: pause for debugging
-  ansible.builtin.pause:
-    prompt: "Enter to continue"
-  
 - name: Check if kubelet.conf exists
   stat:
     path: "{{ kube_config_dir }}/kubelet.conf"
@@ -154,6 +150,10 @@
         msg: |
           Joined with warnings
           {{ kubeadm_join.stderr_lines }}
+    - name: Delete the temporary discovery file
+      ansible.builtin.file:
+        path: "{{ discovery_file }}"
+        state: absent
 
 - name: Update server field in kubelet kubeconfig
   lineinfile:

--- a/kubespray/scale.yml
+++ b/kubespray/scale.yml
@@ -108,6 +108,10 @@
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
+  pre_tasks:
+    - name: set discovery_type to file
+      ansible.builtin.set_fact:
+        discovery_type: "file"
   roles:
     - { role: kubespray-defaults }
     - { role: kubernetes/kubeadm, tags: kubeadm }


### PR DESCRIPTION
There is a problem with joining node when --anonymous-auth is false in kube-apiserver.
Kubeadm uses token-based discovery but it needs anonymous auth on kube-apiserver to get cluster information.
So I added file-based discovery so that a node can join the cluster with it.