### PR TITLE
fix: add first controller ip in localrepo section of haproxy

### DIFF
--- a/roles/burrito.localrepo/tasks/main.yml
+++ b/roles/burrito.localrepo/tasks/main.yml
@@ -108,6 +108,7 @@
     block: >-
       listen localrepo
           bind {{ keepalived_vip }}:{{ local_repo_port }}
+          bind {{ hostvars[groups['kube_control_plane'][0]].ip }}:{{ local_repo_port }}
           option forwardfor except 127.0.0.0/8
           balance {{ balance }}
           option httpchk GET /


### PR DESCRIPTION
- feature: add genesis registry to serve local registry image
- refactor: move offline vars from vars.yml to offline_vars.yml
- hotfix: do not remove offline_flag; add head -1 to get the repo/registry pids
- fix: add the first controller ip bind in haproxy setup on localrepo role
