### PR TITLE
fix: ntp_servers for offline installation

### DIFF
--- a/roles/burrito.ntp/defaults/main.yml
+++ b/roles/burrito.ntp/defaults/main.yml
@@ -2,7 +2,7 @@
 service_name: "chrony"
 ntp_allowed_cidr: ~
 
-default_ntp_servers:
+ntp_servers:
   - 0.pool.ntp.org
   - 1.pool.ntp.org
   - 2.pool.ntp.org

--- a/roles/burrito.ntp/templates/redhat/etc/chrony.conf.j2
+++ b/roles/burrito.ntp/templates/redhat/etc/chrony.conf.j2
@@ -1,13 +1,13 @@
 initstepslew 1 {% for h in groups['kube_control_plane'] %}{% if inventory_hostname != h %}{{ hostvars[h].ip }} {% endif %}{% endfor %}
 
-{% if offline %}
+{% if ntp_servers|length == 0 %}
 {% for h in groups['kube_control_plane'] %}
 {% if inventory_hostname != h %}
 server {{ hostvars[h].ip }}
 {% endif %}
 {% endfor %}
 {% else %}
-{% for ntp_server in default_ntp_servers %}
+{% for ntp_server in ntp_servers %}
 server {{ ntp_server }}
 {% endfor %}
 {% endif %}

--- a/vars.yml.sample
+++ b/vars.yml.sample
@@ -7,6 +7,17 @@ mgmt_iface_name: eth1
 provider_iface_name: eth2
 overlay_iface_name: eth3
 
+## ntp
+# Specify time servers for control nodes.
+# You can use the default ntp.org servers or time servers in your network.
+# If servers are offline and there is no time server in your network,
+#   set ntp_servers to empty list.
+#   Then, the control nodes will be the ntp peers.
+ntp_servers:
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+  - 2.pool.ntp.org
+
 ## ceph-ansible                     #
 # ceph network cidr - recommend the same cidr for public/cluster networks.
 public_network: 192.168.24.0/24
@@ -26,8 +37,6 @@ pod:
 ### keepalived role variables
 keepalived_interface: "{{ mgmt_iface_name }}"
 keepalived_vip: "192.168.21.90"
-keepalived_interface_svc: "{{ svc_iface_name }}"
-keepalived_vip_svc: "192.168.20.90"
 
 ### MTU setting
 calico_mtu: 1500
@@ -50,10 +59,6 @@ offline: false
 # ntp
 mgmt_netmask: "{{ hostvars[inventory_hostname]['ansible_' + mgmt_iface_name].ipv4.network }}/{{ hostvars[inventory_hostname]['ansible_' + mgmt_iface_name].ipv4.netmask }}"
 ntp_allowed_cidr: "{{ mgmt_netmask | ansible.utils.ipaddr('net') }}"
-default_ntp_servers:
-  - 0.pool.ntp.org
-  - 1.pool.ntp.org
-  - 2.pool.ntp.org
 
 # make keepalived service vip optional.
 # keepalived service interface vip for future use (default: no setup).


### PR DESCRIPTION
Specify time servers for control nodes; If there is no time server, set ntp_servers to empty list.