### PR TITLE
fix: change kube-node to kube_node in cripatch.yml

### DIFF
--- a/cripatch.yml
+++ b/cripatch.yml
@@ -1,6 +1,6 @@
 ---
 - name: patch containerd
-  hosts: kube-node
+  hosts: kube_node
   gather_facts: true
   any_errors_fatal: true
 


### PR DESCRIPTION
change legacy group name kube-node to kube_node in cripatch.yml