### PR TITLE
feature: update btx to 1.0.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -246,16 +246,14 @@ Source btx environment and run btx in test mode.::
 
 The command "btx --test"
 
-* Creates a private/provider network and subnet
-  When it creates provider network, it will ask address pool range.
-* Creates a router
-* Creates a cirros image
-* Adds security group rules
-* Creates a flavor
-* Creates an instance
-* Adds a floating ip to an instance
-* Creates a volume
-* Attaches a volume to an instance
+* Creates a provider network and subnet.
+  When it creates a provider network, it will ask an address pool range.
+* Creates a cirros image.
+* Adds security group rules.
+* Creates a flavor.
+* Creates an instance.
+* Creates a volume.
+* Attaches a volume to an instance.
 
 If everything goes well, the output looks like this.::
 
@@ -271,7 +269,7 @@ If everything goes well, the output looks like this.::
    +------------------+------------------------------------------------+
    | Field            | Value                                          |
    +------------------+------------------------------------------------+
-   | addresses        | private-net=172.30.1.30, 192.168.22.195        |
+   | addresses        | private-net=192.168.22.207                     |
    | flavor           | m1.tiny (410f3140-3fb5-4efb-94e5-73d77d6242cf) |
    | image            | cirros (870cf94b-8d2b-43bd-b244-4bf7846ff39e)  |
    | name             | test                                           |

--- a/README_offline.rst
+++ b/README_offline.rst
@@ -277,16 +277,14 @@ Source btx environment and run btx in test mode.::
 
 The command "btx --test"
 
-* Creates a private/provider network and subnet
-  When it creates provider network, it will ask address pool range.
-* Creates a router
-* Creates a cirros image
-* Adds security group rules
-* Creates a flavor
-* Creates an instance
-* Adds a floating ip to an instance
-* Creates a volume
-* Attaches a volume to an instance
+* Creates a provider network and subnet.
+  When it creates a provider network, it will ask an address pool range.
+* Creates a cirros image.
+* Adds security group rules.
+* Creates a flavor.
+* Creates an instance.
+* Creates a volume.
+* Attaches a volume to an instance.
 
 If everything goes well, the output looks like this.::
 
@@ -302,7 +300,7 @@ If everything goes well, the output looks like this.::
    +------------------+------------------------------------------------+
    | Field            | Value                                          |
    +------------------+------------------------------------------------+
-   | addresses        | private-net=172.30.1.30, 192.168.22.195        |
+   | addresses        | private-net=192.168.22.207                     |
    | flavor           | m1.tiny (410f3140-3fb5-4efb-94e5-73d77d6242cf) |
    | image            | cirros (870cf94b-8d2b-43bd-b244-4bf7846ff39e)  |
    | name             | test                                           |

--- a/kubespray/roles/burrito.openstack/templates/btx.yml.j2
+++ b/kubespray/roles/burrito.openstack/templates/btx.yml.j2
@@ -6,5 +6,5 @@ openstack:
   password: "{{ os_admin_password }}"
 image:
   repo: {{ containerd_insecure_registries.local_registry }}/jijisa/btx
-  tag: yoga-v1.24.8-quincy
+  tag: {{ btx.version }}
 ...

--- a/scripts/images.txt
+++ b/scripts/images.txt
@@ -1,5 +1,5 @@
 docker.io/jijisa/barbican:yoga-ubuntu_focal
-docker.io/jijisa/btx:yoga-v1.24.8-quincy
+docker.io/jijisa/btx:1.0.0
 docker.io/jijisa/cinder:yoga-ubuntu_focal
 docker.io/jijisa/glance:yoga-ubuntu_focal
 docker.io/jijisa/heat:yoga-ubuntu_focal

--- a/vars.yml.sample
+++ b/vars.yml.sample
@@ -292,6 +292,7 @@ barbican:
 
 ### btx
 btx:
+  version: "1.0.0"
   pvc:
     size: "100Gi"
 ...


### PR DESCRIPTION
* btx modifications

   - add provider-network-only VM creation option in btx --test.
     and make it the default option.
   - add --selfservice option to create a VM with private network and
     floating ip.

* burrito modifications

   - add btx.version to 1.0.0 in vars.yml.sample
   - use btx.version in kubespray/roles/burrito.openstack/templates/btx.yml.j2
   - change btx image tag to 1.0.0 in scripts/images.txt
