### PR TITLE
Rabbitmq start.sh 수정

### DIFF
--- a/openstack-helm-infra/rabbitmq/templates/bin/_rabbitmq-start.sh.tpl
+++ b/openstack-helm-infra/rabbitmq/templates/bin/_rabbitmq-start.sh.tpl
@@ -24,7 +24,7 @@ function check_if_open () {
 
 function check_rabbit_node_health () {
   CLUSTER_SEED_NAME=$1
-  rabbitmq-diagnostics node_health_check -n "${CLUSTER_SEED_NAME}" -t 10 &>/dev/null
+  rabbitmq-diagnostics -q status -n "${CLUSTER_SEED_NAME}" -t 10 &>/dev/null
 }
 
 get_node_name () {


### PR DESCRIPTION
현재 rabbitmq에서 권장하지 않는 health check를 사용하고있어 수정하였습니다.
현재 사용중인 health check 방식의 경우 resource를 많이 잡아먹으며, 오탐이 발생하기 쉽다고 공식Docs에서는 이야기하고 있습니다. 따라서 조금 더 오탐확률이 적은 health check로 수정하였습니다.
( rabbitmq docs:: https://www.rabbitmq.com/monitoring.html )