### PR TITLE
feature: add randomly generated kek in barbican.conf

### DIFF
--- a/kubespray/roles/burrito.openstack/defaults/main.yml
+++ b/kubespray/roles/burrito.openstack/defaults/main.yml
@@ -92,6 +92,7 @@ horizon:
 ## barbican
 barbican:
   password: ~
+  kek: ~
 
 ## btx
 btx:

--- a/kubespray/roles/burrito.openstack/templates/osh/barbican.yml.j2
+++ b/kubespray/roles/burrito.openstack/templates/osh/barbican.yml.j2
@@ -24,6 +24,8 @@ conf:
       ssl_ca_file: /etc/rabbitmq/certs/ca.crt
       ssl_cert_file: /etc/rabbitmq/certs/tls.crt
       ssl_key_file: /etc/rabbitmq/certs/tls.key
+    simple_crypto_plugin:
+      kek: '{{ barbican.kek }}'
 
 endpoints:
   identity:


### PR DESCRIPTION
kek setup in simple_crypto_plugin section of barbican.conf