### PR TITLE
Create scale.yml to use when adding k8s compute node

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -19,6 +19,7 @@ function USAGE() {
   echo "registry  - play local registry setup tasks."
   echo "burrito   - play openstack installation tasks."
   echo "landing   - play localrepo/genesis registry setup tasks.(offline only)"
+  echo "scale     - play kubernetes add to node tasks."
   echo
   echo "ansible_parameters"
   echo "=================="
@@ -51,7 +52,12 @@ if [ -f .offline_flag ]; then
     exit 1
   fi
 fi
-[[ "${PLAYBOOK}" = "k8s" ]] && FLAGS="-b" || FLAGS=""
+
+if [[ "${PLAYBOOK}" = "k8s" || "${PLAYBOOK}" = "scale" ]]; then
+  FLAGS="-b"
+else
+  FLAGS=""
+fi
 FLAGS="${FLAGS} $@"
 
 if [[ "${PLAYBOOK}" = "burrito" && -n ${OFFLINE_VARS} ]]; then

--- a/scale.yml
+++ b/scale.yml
@@ -1,0 +1,5 @@
+---
+# Add To K8S NODE
+- import_playbook: kubespray/scale.yml
+...
+


### PR DESCRIPTION
k8s compute node를 추가할 때,
./run.sh k8s를 수행하는 것보단 kubespary에서 사용하고있는 scale.yml을 사용하도록 고려해보았습니다.

run.sh에 scale을 추가하였으며, k8s와 마찬가지로 -b flag를 사용할 수 있도록 넣었습니다.

sclae.yml에는 k8s만 넣도록하였으며, openstack 을 배포하는 burrito.yml의 경우, iso가 mount되어야만 burrito.yml이 수행됨으로
langding을 마친 곳에서는 수행이 불가능하여 추가하진 않았습니다.
따라서 openstack 쪽 배포는 burrito.sh을 통하여 배포할 수 있도록 하는 것이 좋을 듯 해보입니다.