### PR TITLE
Sacle

### DIFF
--- a/docs/add_compute_node.rst
+++ b/docs/add_compute_node.rst
@@ -23,10 +23,10 @@ Edit inventory hosts to add the new compute node.::
    --- hosts.bak        2023-02-20 13:54:45.365350417 +0900
    +++ hosts    2023-02-20 14:43:02.897660764 +0900
    @@ -1,6 +1,7 @@
-    bon-controller ip=192.168.21.121 ansible_port=22 ansible_user=clex ansible_connection=local ansible_python_interpreter=/usr/bin/python3
-    bon-compute ip=192.168.21.122 ansible_port=22 ansible_user=clex
-    bon-storage ip=192.168.21.123 monitor_address=192.168.24.123 radosgw_address=192.168.24.123 ansible_port=22 ansible_user=clex
-   +bon-compute2 ip=192.168.21.124 ansible_port=22 ansible_user=clex
+    bon-controller ip=192.168.21.121 ansible_connection=local ansible_python_interpreter=/usr/bin/python3
+    bon-compute ip=192.168.21.122 
+    bon-storage ip=192.168.21.123 monitor_address=192.168.24.123 radosgw_address=192.168.24.123
+   +bon-compute2 ip=192.168.21.124
 
     # ceph nodes
     [mons]
@@ -56,7 +56,7 @@ Edit inventory hosts to add the new compute node.::
 
 Check the connection to the new node bon-compute2.::
 
-   $ ansible -m ping bon-compute2
+   $ ./run.sh ping
    bon-compute2 | SUCCESS => {
        "ansible_facts": {
            "discovered_interpreter_python": "/usr/libexec/platform-python"
@@ -77,9 +77,7 @@ Run ceph playbook.::
 
 Add the node to k8s cluster.::
 
-   $ source ~/.envs/burrito/bin/activate
-   $ ansible-playbook -i hosts --extra-vars=@vars.yml -b kubespray/scale.yml \
-      --limit=bon-compute2
+   $ ./run.sh scale --limit=bon-compute2
 
 Check if the new node is added as a k8s node.::
 
@@ -93,7 +91,7 @@ Skip patch, registry playbook since it is the compute node.
 
 Run burrito playbook with k8s-burrito and novakey-burrito tags.::
 
-   $ ./run.sh burrito --tags=k8s-burrito,novakey-burrito
+   $ ./run.sh novakey
 
 Check the node is added as a compute node.::
 

--- a/novakey.yml
+++ b/novakey.yml
@@ -1,0 +1,13 @@
+---
+- name: Deploy k8s burrito playbook
+  any_errors_fatal: true
+  ansible.builtin.import_playbook: kubespray/burrito.yml
+  tags: k8s-burrito
+
+- name: Deploy nova compute sshkey copy playbook
+  any_errors_fatal: true
+  ansible.builtin.import_playbook: nova_compute_sshkey_copy/setup.yml
+  tags: novakey-burrito
+
+...
+

--- a/run.sh
+++ b/run.sh
@@ -19,6 +19,7 @@ function USAGE() {
   echo "registry  - play local registry setup tasks."
   echo "burrito   - play openstack installation tasks."
   echo "landing   - play localrepo/genesis registry setup tasks.(offline only)"
+  echo "scale     - play kubernetes add to node tasks."
   echo
   echo "ansible_parameters"
   echo "=================="
@@ -51,7 +52,12 @@ if [ -f .offline_flag ]; then
     exit 1
   fi
 fi
-[[ "${PLAYBOOK}" = "k8s" ]] && FLAGS="-b" || FLAGS=""
+
+if [[ "${PLAYBOOK}" = "k8s" || "${PLAYBOOK}" = "scale" ]]; then
+  FLAGS="-b"
+else
+  FLAGS=""
+fi
 FLAGS="${FLAGS} $@"
 
 if [[ "${PLAYBOOK}" = "burrito" && -n ${OFFLINE_VARS} ]]; then

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,8 @@ function USAGE() {
   echo "registry  - play local registry setup tasks."
   echo "burrito   - play openstack installation tasks."
   echo "landing   - play localrepo/genesis registry setup tasks.(offline only)"
-  echo "scale     - play kubernetes add to node tasks."
+  echo "scale     - play Add kubernetes compute node task."
+  echo "novakey   - play k8s-burrito and novakey-burrito tasks."
   echo
   echo "ansible_parameters"
   echo "=================="

--- a/scale.yml
+++ b/scale.yml
@@ -1,0 +1,5 @@
+---
+# Add To K8S NODE
+- import_playbook: kubespray/scale.yml
+...
+


### PR DESCRIPTION
./run.sh sclae task를 추가하여 k8s compute node를 추가할 수 있도록 반영해보았습니다.
./run.sh novakey task를 추가하여 nova ssh key 를 수행할 수 있도록 반영해보았습니다.
(./run.sh burrito를 사용하지않는 이유는, burrito 를 실행할 시, helm plugin을 설치하는데 이를 설치하기 위해서는 burrito-<version>.iso가 필요하기 때문입니다. 기존 plugin을 설치하였기 때문에 또 설치할 필요는 없다 생각하여 새로운 task를 생성하였습니다.)

위 2가지 방법을 추가한 add_compute_node.rst를 최신화하였습니다.
검토부탁드립니다.
감사합니다.