### PR TITLE
fix: update registry tarball and image to 2.8.2

### DIFF
--- a/roles/burrito.genesisregistry/defaults/main.yml
+++ b/roles/burrito.genesisregistry/defaults/main.yml
@@ -3,7 +3,7 @@ genesis_registry:
   root_dir: "/var/lib/registry"
   secret: "{{ lookup('community.general.random_string', length=12, base64=True) }}"
   conf: "/etc/genesis_registry.conf"
-  image: "library/registry:2.8.1"
+  image: "library/registry:{{ registry_version }}"
   addr: "{{ hostvars[inventory_hostname].ip }}:{{ genesis_registry_port }}"
 
 keepalived_vip: ~

--- a/scripts/bin.txt
+++ b/scripts/bin.txt
@@ -3,7 +3,7 @@ https://github.com/containerd/containerd/releases/download/v1.6.9/containerd-1.6
 https://github.com/containerd/nerdctl/releases/download/v1.0.0/nerdctl-1.0.0-linux-amd64.tar.gz
 https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz
 https://github.com/databus23/helm-diff/releases/download/v3.6.0/helm-diff-linux-amd64.tgz
-https://github.com/distribution/distribution/releases/download/v2.8.1/registry_2.8.1_linux_amd64.tar.gz
+https://github.com/distribution/distribution/releases/download/v2.8.2/registry_2.8.2_linux_amd64.tar.gz
 https://github.com/etcd-io/etcd/releases/download/v3.5.4/etcd-v3.5.4-linux-amd64.tar.gz
 https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.24.0/crictl-v1.24.0-linux-amd64.tar.gz
 https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-linux_amd64.tar.gz

--- a/scripts/images.txt
+++ b/scripts/images.txt
@@ -17,7 +17,7 @@ docker.io/library/nginx:1.23
 docker.io/library/nginx:1.23.0-alpine
 docker.io/library/rabbitmq:3.11
 docker.io/library/rabbitmq:3.11-management
-docker.io/library/registry:2.8.1
+docker.io/library/registry:2.8.2
 docker.io/netapp/trident:22.10.0
 docker.io/netapp/trident-autosupport:22.10
 docker.io/openstackhelm/ceph-config-helper:latest-ubuntu_focal

--- a/vars.yml.sample
+++ b/vars.yml.sample
@@ -213,6 +213,7 @@ calico_ipip_mode: 'Never'
 calico_vxlan_mode: 'Never'
 
 # Registry deployment
+registry_version: "2.8.2"
 registry_enabled: "{{ offline|ternary(true, false) }}"
 registry_namespace: kube-system
 registry_storage_class: "{{ storage_backends[0] }}"


### PR DESCRIPTION
fix: update registry tarball and image to 2.8.2; fix: CVE-2023-2253 runaway allocation on /v2/_catalog