### PR TITLE
fix: patch registry replicaset to add nodeSelector

### DIFF
--- a/patches/09-patch-kubespray-registry-template-registry-rs-yaml.txt
+++ b/patches/09-patch-kubespray-registry-template-registry-rs-yaml.txt
@@ -1,0 +1,11 @@
+--- kubespray/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2	2023-06-07 17:51:18.377141502 +0900
++++ patches/kubespray/roles/kubernetes-apps/registry/templates/registry-rs.yml.j2	2023-06-14 16:07:22.598864608 +0900
+@@ -24,6 +24,8 @@
+         k8s-app: registry
+         version: v{{ registry_image_tag }}
+     spec:
++      nodeSelector:
++        node-role.kubernetes.io/control-plane: ""
+       priorityClassName: {% if registry_namespace == 'kube-system' %}system-cluster-critical{% else %}k8s-cluster-critical{% endif %}{{''}}
+       serviceAccountName: registry
+       securityContext:


### PR DESCRIPTION
This is a regression bug. Burrito 1.1.3 has nodeSelector in registry replicaset. But it was removed in 1.2.0 when migrating kubespray to upstream version.