### PR TITLE
fix: solve the deadlock between ceph-csi and local registry

### DIFF
--- a/roles/burrito.ceph-csi/defaults/main.yml
+++ b/roles/burrito.ceph-csi/defaults/main.yml
@@ -13,4 +13,12 @@ template_files:
   - {dest: "{{ artifacts_dir }}/06-csi-rbdplugin-provisioner.yaml"}
   - {dest: "{{ artifacts_dir }}/07-csi-rbdplugin.yaml"}
   - {dest: "{{ artifacts_dir }}/08-csi-rbd-sc.yml"}
+
+# container image versions
+cephcsi_version: "v3.7.2"
+csi_attacher_version: "v4.0.0"
+csi_node_driver_registrar_version: "v2.5.1"
+csi_provisioner_version: "v3.3.0"
+csi_resizer_version: "v1.6.0"
+csi_snapshooter_version: "v6.1.0"
 ...

--- a/roles/burrito.ceph-csi/templates/06-csi-rbdplugin-provisioner.yaml.j2
+++ b/roles/burrito.ceph-csi/templates/06-csi-rbdplugin-provisioner.yaml.j2
@@ -47,7 +47,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: csi-provisioner
-          image: {{ kube_image_repo }}/sig-storage/csi-provisioner:v3.3.0
+          image: {{ kube_image_repo }}/sig-storage/csi-provisioner:{{ csi_provisioner_version }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=1"
@@ -69,7 +69,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-snapshotter
-          image: {{ kube_image_repo }}/sig-storage/csi-snapshotter:v6.1.0
+          image: {{ kube_image_repo }}/sig-storage/csi-snapshotter:{{ csi_snapshooter_version }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=1"
@@ -84,7 +84,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: {{ kube_image_repo }}/sig-storage/csi-attacher:v4.0.0
+          image: {{ kube_image_repo }}/sig-storage/csi-attacher:{{ csi_attacher_version }}
           args:
             - "--v=1"
             - "--csi-address=$(ADDRESS)"
@@ -99,7 +99,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: {{ kube_image_repo }}/sig-storage/csi-resizer:v1.6.0
+          image: {{ kube_image_repo }}/sig-storage/csi-resizer:{{ csi_resizer_version }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=1"
@@ -117,7 +117,7 @@ spec:
               mountPath: /csi
         - name: csi-rbdplugin
           # for stable functionality replace canary with latest release version
-          image: {{ quay_image_repo }}/cephcsi/cephcsi:v3.7.2
+          image: {{ quay_image_repo }}/cephcsi/cephcsi:{{ cephcsi_version }}
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -174,7 +174,7 @@ spec:
               readOnly: true
         - name: csi-rbdplugin-controller
           # for stable functionality replace canary with latest release version
-          image: {{ quay_image_repo }}/cephcsi/cephcsi:v3.7.2
+          image: {{ quay_image_repo }}/cephcsi/cephcsi:{{ cephcsi_version }}
           args:
             - "--type=controller"
             - "--v=5"
@@ -195,7 +195,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: {{ quay_image_repo }}/cephcsi/cephcsi:v3.7.2
+          image: {{ quay_image_repo }}/cephcsi/cephcsi:{{ cephcsi_version }}
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/roles/burrito.ceph-csi/templates/06-csi-rbdplugin-provisioner.yaml.j2
+++ b/roles/burrito.ceph-csi/templates/06-csi-rbdplugin-provisioner.yaml.j2
@@ -26,6 +26,11 @@ spec:
   selector:
     matchLabels:
       app: csi-rbdplugin-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/roles/burrito.ceph-csi/templates/07-csi-rbdplugin.yaml.j2
+++ b/roles/burrito.ceph-csi/templates/07-csi-rbdplugin.yaml.j2
@@ -28,7 +28,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: {{ kube_image_repo }}/sig-storage/csi-node-driver-registrar:v2.5.1
+          image: {{ kube_image_repo }}/sig-storage/csi-node-driver-registrar:{{ csi_node_driver_registrar_version }}
           args:
             - "--v=1"
             - "--csi-address=/csi/csi.sock"
@@ -50,7 +50,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: {{ quay_image_repo }}/cephcsi/cephcsi:v3.7.2
+          image: {{ quay_image_repo }}/cephcsi/cephcsi:{{ cephcsi_version }}
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
@@ -125,7 +125,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: {{ quay_image_repo }}/cephcsi/cephcsi:v3.7.2
+          image: {{ quay_image_repo }}/cephcsi/cephcsi:{{ cephcsi_version }}
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/roles/burrito.genesisregistry/defaults/main.yml
+++ b/roles/burrito.genesisregistry/defaults/main.yml
@@ -3,7 +3,14 @@ genesis_registry:
   root_dir: "/var/lib/registry"
   secret: "{{ lookup('community.general.random_string', length=12, base64=True) }}"
   conf: "/etc/genesis_registry.conf"
-  image: "library/registry:{{ registry_version }}"
+  images:
+    - "library/registry:{{ registry_version }}"
+    - "cephcsi/cephcsi:{{ cephcsi_version }}"
+    - "sig-storage/csi-attacher:{{ csi_attacher_version }}"
+    - "sig-storage/csi-node-driver-registrar:{{ csi_node_driver_registrar_version }}"
+    - "sig-storage/csi-provisioner:{{ csi_provisioner_version }}"
+    - "sig-storage/csi-resizer:{{ csi_resizer_version }}"
+    - "sig-storage/csi-snapshotter:{{ csi_snapshooter_version }}"
   addr: "{{ hostvars[inventory_hostname].ip }}:{{ genesis_registry_port }}"
 
 keepalived_vip: ~
@@ -11,4 +18,5 @@ balance: roundrobin
 inter: 2s
 rise: 2
 fall: 3
+
 ...

--- a/roles/burrito.genesisregistry/defaults/main.yml
+++ b/roles/burrito.genesisregistry/defaults/main.yml
@@ -18,5 +18,29 @@ balance: roundrobin
 inter: 2s
 rise: 2
 fall: 3
+# csi_rbdplugin daemonset patch variables
+csi_rbdplugin_images:
+  - "sig-storage/csi-node-driver-registrar:{{ csi_node_driver_registrar_version }}"
+  - "cephcsi/cephcsi:{{ cephcsi_version }}"
+  - "cephcsi/cephcsi:{{ cephcsi_version }}"
+rbdplugins: |
+  {% for v in csi_rbdplugin_images -%}
+  {op: replace, "path": "/spec/template/spec/containers/{{ loop.index0 }}/image", value: "{{ containerd_insecure_registries.genesis_registry }}/{{ v }}"}
+  {% endfor -%}
+rbdplugin_patch_list: "{{ rbdplugins.splitlines()|map('from_yaml')|list }}"
 
+# csi_rbdplugin_provisioner deployment patch variables
+csi_rbdplugin_provisioner_images:
+  - "sig-storage/csi-provisioner:{{ csi_provisioner_version }}"
+  - "sig-storage/csi-snapshotter:{{ csi_snapshooter_version }}"
+  - "sig-storage/csi-attacher:{{ csi_attacher_version }}"
+  - "sig-storage/csi-resizer:{{ csi_resizer_version }}"
+  - "cephcsi/cephcsi:{{ cephcsi_version }}"
+  - "cephcsi/cephcsi:{{ cephcsi_version }}"
+  - "cephcsi/cephcsi:{{ cephcsi_version }}"
+provisioner: |
+  {% for v in csi_rbdplugin_provisioner_images -%}
+  {op: replace, path: "/spec/template/spec/containers/{{ loop.index0 }}/image", value: "{{ containerd_insecure_registries.genesis_registry }}/{{ v }}"}
+  {% endfor -%}
+provisioner_patch_list: "{{ provisioner.splitlines()|map('from_yaml')|list }}"
 ...

--- a/roles/burrito.genesisregistry/tasks/main.yml
+++ b/roles/burrito.genesisregistry/tasks/main.yml
@@ -73,17 +73,6 @@
   become: true
   loop: "{{ genesis_registry.images }}"
 
-- name: Genesis Registry | take down offline services
-  ansible.builtin.shell: >-
-    ./offline_services.sh --down registry
-  args:
-    chdir: "{{ playbook_dir }}/scripts"
-  become: true
-  register: res
-  failed_when: res.rc not in [0, 10]
-  delegate_to: "{{ groups['kube_control_plane'][0] }}"
-  run_once: true
-
 - name: Genesis Registry | add genesis registry section in haproxy.cfg
   ansible.builtin.blockinfile:
     path: "/etc/haproxy/haproxy.cfg"
@@ -127,67 +116,32 @@
 
 - name: Genesis Registry | apply patch to csi-rbdplugin daemonset
   kubernetes.core.k8s_json_patch:
-    kind: ReplicaSet
+    kind: DaemonSet
     namespace: "ceph-csi"
     name: csi-rbdplugin
-    patch:
-      - op: replace
-        path: "/spec/template/spec/containers/{{ idx }}/image"
-        value: "{{ containerd_insecure_registries.genesis_registry }}/{{ item }}"
+    patch: "{{ rbdplugin_patch_list }}"
   become: true
   delegate_to: localhost
   run_once: true
-  loop:
-    - "sig-storage/csi-node-driver-registrar:{{ csi_node_driver_registrar_version }}"
-    - "cephcsi/cephcsi:{{ cephcsi_version }}"
-    - "cephcsi/cephcsi:{{ cephcsi_version }}"
-  loop_control:
-    index_var: idx
 
 - name: Genesis Registry | apply patch to csi-rbdplugin-provisioner deployment
   kubernetes.core.k8s_json_patch:
-    kind: ReplicaSet
+    kind: Deployment
     namespace: "ceph-csi"
-    name: csi-rbdplugin
-    patch:
-      - op: replace
-        path: "/spec/template/spec/containers/{{ idx }}/image"
-        value: "{{ containerd_insecure_registries.genesis_registry }}/{{ item }}"
+    name: csi-rbdplugin-provisioner
+    patch: "{{ provisioner_patch_list }}"
   become: true
   delegate_to: localhost
   run_once: true
-  loop:
-    - "sig-storage/csi-provisioner:{{ csi_provisioner_version }}"
-    - "sig-storage/csi-snapshotter:{{ csi_snapshooter_version }}"
-    - "sig-storage/csi-attacher:{{ csi_attacher_version }}"
-    - "sig-storage/csi-resizer:{{ csi_resizer_version }}"
-    - "cephcsi/cephcsi:{{ cephcsi_version }}"
-    - "cephcsi/cephcsi:{{ cephcsi_version }}"
-    - "cephcsi/cephcsi:{{ cephcsi_version }}"
-  loop_control:
-    index_var: idx
 
-# Do not run the below tasks since it is unnessary tasks. 
-# ReplicaSet does not update image automatically
-# So I need to kill it.
-#- name: Genesis Registry | get registry pod name
-#  kubernetes.core.k8s_info:
-#    kind: Pod
-#    namespace: "{{ registry_namespace }}"
-#    label_selectors:
-#      - "k8s-app=registry"
-#  register: registry_pod
-#  delegate_to: localhost
-#  run_once: true
-#
-#- name: Genesis Registry | kill the registry
-#  kubernetes.core.k8s:
-#    state: absent
-#    api_version: v1
-#    namespace: "{{ registry_namespace }}"
-#    kind: Pod
-#    name: "{{ registry_pod.resources[0].metadata.name }}"
-#  become: true
-#  delegate_to: localhost
-#  run_once: true
+- name: Genesis Registry | take down offline services
+  ansible.builtin.shell: >-
+    ./offline_services.sh --down registry
+  args:
+    chdir: "{{ playbook_dir }}/scripts"
+  become: true
+  register: res
+  failed_when: res.rc not in [0, 10]
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  run_once: true
 ...

--- a/roles/burrito.genesisregistry/tasks/main.yml
+++ b/roles/burrito.genesisregistry/tasks/main.yml
@@ -54,21 +54,24 @@
 - name: Genesis Registry | pull registry image from seed registry
   ansible.builtin.shell: >-
     nerdctl pull \
-      {{ containerd_insecure_registries.seed_registry }}/{{genesis_registry.image }}
+      {{ containerd_insecure_registries.seed_registry }}/{{ item }}
   become: true
+  loop: "{{ genesis_registry.images }}"
 
 - name: Genesis Registry | tag registry image for genesis registry
   ansible.builtin.shell: >-
     nerdctl tag \
-      {{ containerd_insecure_registries.seed_registry }}/{{genesis_registry.image }} \
-      {{ hostvars[inventory_hostname].ip }}:{{ genesis_registry_port }}/{{genesis_registry.image }}
+      {{ containerd_insecure_registries.seed_registry }}/{{ item }} \
+      {{ hostvars[inventory_hostname].ip }}:{{ genesis_registry_port }}/{{ item }}
   become: true
+  loop: "{{ genesis_registry.images }}"
 
 - name: Genesis Registry | push registry image to each genesis registry
   ansible.builtin.shell: >-
     nerdctl push \
-      {{ hostvars[inventory_hostname].ip }}:{{ genesis_registry_port }}/{{genesis_registry.image }}
+      {{ hostvars[inventory_hostname].ip }}:{{ genesis_registry_port }}/{{ item }}
   become: true
+  loop: "{{ genesis_registry.images }}"
 
 - name: Genesis Registry | take down offline services
   ansible.builtin.shell: >-
@@ -109,7 +112,7 @@
   notify:
     - haproxy restart service
 
-- name: Genesis Registry | apply a patch to registry replicaset
+- name: Genesis Registry | apply patch to registry replicaset
   kubernetes.core.k8s_json_patch:
     kind: ReplicaSet
     namespace: "{{ registry_namespace }}"
@@ -117,31 +120,74 @@
     patch:
       - op: replace
         path: /spec/template/spec/containers/0/image
-        value: "{{ containerd_insecure_registries.genesis_registry }}/{{ genesis_registry.image }}"
+        value: "{{ containerd_insecure_registries.genesis_registry }}/library/registry:{{ registry_version }}"
   become: true
   delegate_to: localhost
   run_once: true
 
+- name: Genesis Registry | apply patch to csi-rbdplugin daemonset
+  kubernetes.core.k8s_json_patch:
+    kind: ReplicaSet
+    namespace: "ceph-csi"
+    name: csi-rbdplugin
+    patch:
+      - op: replace
+        path: "/spec/template/spec/containers/{{ idx }}/image"
+        value: "{{ containerd_insecure_registries.genesis_registry }}/{{ item }}"
+  become: true
+  delegate_to: localhost
+  run_once: true
+  loop:
+    - "sig-storage/csi-node-driver-registrar:{{ csi_node_driver_registrar_version }}"
+    - "cephcsi/cephcsi:{{ cephcsi_version }}"
+    - "cephcsi/cephcsi:{{ cephcsi_version }}"
+  loop_control:
+    index_var: idx
+
+- name: Genesis Registry | apply patch to csi-rbdplugin-provisioner deployment
+  kubernetes.core.k8s_json_patch:
+    kind: ReplicaSet
+    namespace: "ceph-csi"
+    name: csi-rbdplugin
+    patch:
+      - op: replace
+        path: "/spec/template/spec/containers/{{ idx }}/image"
+        value: "{{ containerd_insecure_registries.genesis_registry }}/{{ item }}"
+  become: true
+  delegate_to: localhost
+  run_once: true
+  loop:
+    - "sig-storage/csi-provisioner:{{ csi_provisioner_version }}"
+    - "sig-storage/csi-snapshotter:{{ csi_snapshooter_version }}"
+    - "sig-storage/csi-attacher:{{ csi_attacher_version }}"
+    - "sig-storage/csi-resizer:{{ csi_resizer_version }}"
+    - "cephcsi/cephcsi:{{ cephcsi_version }}"
+    - "cephcsi/cephcsi:{{ cephcsi_version }}"
+    - "cephcsi/cephcsi:{{ cephcsi_version }}"
+  loop_control:
+    index_var: idx
+
+# Do not run the below tasks since it is unnessary tasks. 
 # ReplicaSet does not update image automatically
 # So I need to kill it.
-- name: Genesis Registry | get registry pod name
-  kubernetes.core.k8s_info:
-    kind: Pod
-    namespace: "{{ registry_namespace }}"
-    label_selectors:
-      - "k8s-app=registry"
-  register: registry_pod
-  delegate_to: localhost
-  run_once: true
-
-- name: Genesis Registry | kill the registry
-  kubernetes.core.k8s:
-    state: absent
-    api_version: v1
-    namespace: "{{ registry_namespace }}"
-    kind: Pod
-    name: "{{ registry_pod.resources[0].metadata.name }}"
-  become: true
-  delegate_to: localhost
-  run_once: true
+#- name: Genesis Registry | get registry pod name
+#  kubernetes.core.k8s_info:
+#    kind: Pod
+#    namespace: "{{ registry_namespace }}"
+#    label_selectors:
+#      - "k8s-app=registry"
+#  register: registry_pod
+#  delegate_to: localhost
+#  run_once: true
+#
+#- name: Genesis Registry | kill the registry
+#  kubernetes.core.k8s:
+#    state: absent
+#    api_version: v1
+#    namespace: "{{ registry_namespace }}"
+#    kind: Pod
+#    name: "{{ registry_pod.resources[0].metadata.name }}"
+#  become: true
+#  delegate_to: localhost
+#  run_once: true
 ...

--- a/vars.yml.sample
+++ b/vars.yml.sample
@@ -243,7 +243,6 @@ podsecuritypolicy_restricted_spec:
         max: 65535
   readOnlyRootFilesystem: false
 
-  
 # calico
 calico_network_backend: bird
 calico_ipip_mode: 'Never'
@@ -289,10 +288,18 @@ metallb_config:
     metallb_peers: {}
 
 ### burrito variables
-# haproxy role variables
+# burrito.haproxy role variables
 ceph_rgw_port: 7480
 
-# kubespray/roles/burrito.openstack/.../ceph_provisioners.yml.j2
+# burrito.ceph-csi role variables
+cephcsi_version: "v3.7.2"
+csi_attacher_version: "v4.0.0"
+csi_node_driver_registrar_version: "v2.5.1"
+csi_provisioner_version: "v3.3.0"
+csi_resizer_version: "v1.6.0"
+csi_snapshooter_version: "v6.1.0"
+
+# burrito.openstack role variables
 ceph_public_network: "{{ public_network }}"
 ceph_cluster_network: "{{ cluster_network }}"
 


### PR DESCRIPTION
This is a deadlock bug.
When all control nodes are shut down and start,
the local registry and ceph-csi depends on each other so that they are in 
the deadlock situation.
To solve it, add ceph-csi images to genesis registry and ceph-csi gets images
from genesis registry.

