### PR TITLE
fix: add nas_secure_file* parameters in cinder netapp backend

### DIFF
--- a/roles/burrito.openstack/templates/osh/cinder.yml.j2
+++ b/roles/burrito.openstack/templates/osh/cinder.yml.j2
@@ -186,7 +186,6 @@ conf:
 {% if "netapp" in storage_backends %}
 {% for n in netapp %}
     {{ n.name }}:
-      #image_volume_cache_enabled: true
       volume_driver: cinder.volume.drivers.netapp.common.NetAppDriver
       volume_backend_name: {{ n.name }}
       netapp_storage_family: ontap_cluster
@@ -197,6 +196,8 @@ conf:
       netapp_password: "{{ n.password }}"
       nfs_mount_options: "{{ n.nfsMountOptions }}"
       nfs_shares_config: "/etc/cinder/share_{{ n.name }}"
+      nas_secure_file_operation = false
+      nas_secure_file_permissions = false
 {% endfor %}
 {% endif %}
 endpoints:


### PR DESCRIPTION
fix: add nas_secure_file* parameters in cinder netapp backend