### PR TITLE
fix: nas_secure_file_* typo in cinder.yml.j2

### DIFF
--- a/roles/burrito.openstack/templates/osh/cinder.yml.j2
+++ b/roles/burrito.openstack/templates/osh/cinder.yml.j2
@@ -196,8 +196,8 @@ conf:
       netapp_password: "{{ n.password }}"
       nfs_mount_options: "{{ n.nfsMountOptions }}"
       nfs_shares_config: "/etc/cinder/share_{{ n.name }}"
-      nas_secure_file_operation = false
-      nas_secure_file_permissions = false
+      nas_secure_file_operation: false
+      nas_secure_file_permissions: false
 {% endfor %}
 {% endif %}
 endpoints:


### PR DESCRIPTION
fix: nas_secure_file_* typo in cinder.yml.j2