### PR TITLE
fix: Set openstack ingress replicas to the number of control nodes

### DIFF
--- a/roles/burrito.openstack/templates/osh_infra/ingress.yml.j2
+++ b/roles/burrito.openstack/templates/osh_infra/ingress.yml.j2
@@ -19,7 +19,7 @@ monitoring:
       scrape: false
 pod:
   replicas:
-    ingress: {{ pod.replicas }}
+    ingress: {{ groups['controller-node']|length }}
     error_page: 1
 endpoints:
   ingress:


### PR DESCRIPTION
fix: Set openstack ingress replicas to the number of control nodes
