### PR TITLE
Aster patch

### DIFF
--- a/openstack-helm/cinder/templates/deployment-volume.yaml
+++ b/openstack-helm/cinder/templates/deployment-volume.yaml
@@ -399,7 +399,6 @@ spec:
 {{- dict "enabled" $envAll.Values.manifests.certificates "name" $envAll.Values.endpoints.oslo_messaging.auth.admin.secret.tls.internal | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
 {{ if $mounts_cinder_volume.volumes }}{{ toYaml $mounts_cinder_volume.volumes | indent 8 }}{{ end }}
 {{- end }}
-{{- if eq .Values.deployment.type "StatefulSet" }}
 {{- if or (eq .Values.deployment.type "StatefulSet") (eq .Values.cinder_conversion_volume.access_modes "ReadWriteMany") }}
   volumeClaimTemplates:
   - metadata:

--- a/openstack-helm/cinder/templates/deployment-volume.yaml
+++ b/openstack-helm/cinder/templates/deployment-volume.yaml
@@ -40,13 +40,8 @@ metadata:
   labels:
 {{ tuple $envAll "cinder" "volume" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
 spec:
-{{- if eq .Values.deployment.type "Deployment" }}
   replicas: {{ .Values.pod.replicas.volume }}
-{{ tuple $envAll | include "helm-toolkit.snippets.kubernetes_upgrades_deployment" | indent 2 }}
-{{- end }}
 {{- if eq .Values.deployment.type "StatefulSet" }}
-  replicas: {{ .Values.pod.replicas.volume }}
-{{ tuple $envAll | include "helm-toolkit.snippets.kubernetes_upgrades_statefulset" | indent 2 }}
   serviceName: cinder-volume
 {{- end }}
   selector:
@@ -405,6 +400,7 @@ spec:
 {{ if $mounts_cinder_volume.volumes }}{{ toYaml $mounts_cinder_volume.volumes | indent 8 }}{{ end }}
 {{- end }}
 {{- if eq .Values.deployment.type "StatefulSet" }}
+{{- if or (eq .Values.deployment.type "StatefulSet") (eq .Values.cinder_conversion_volume.access_modes "ReadWriteMany") }}
   volumeClaimTemplates:
   - metadata:
       name: cinder-conversion-vol

--- a/openstack-helm/cinder/templates/deployment-volume.yaml
+++ b/openstack-helm/cinder/templates/deployment-volume.yaml
@@ -23,8 +23,16 @@ limitations under the License.
 {{- $serviceAccountName := "cinder-volume" }}
 {{ tuple $envAll "volume" $serviceAccountName | include "helm-toolkit.snippets.kubernetes_pod_rbac_serviceaccount" }}
 ---
+{{- if eq .Values.deployment.type "Deployment" }}
 apiVersion: apps/v1
 kind: Deployment
+{{- else if eq .Values.deployment.type "DaemonSet" }}
+apiVersion: apps/v1
+kind: DaemonSet
+{{- else if eq .Values.deployment.type "StatefulSet" }}
+apiVersion: apps/v1
+kind: StatefulSet
+{{- end }}
 metadata:
   name: cinder-volume
   annotations:
@@ -32,11 +40,23 @@ metadata:
   labels:
 {{ tuple $envAll "cinder" "volume" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
 spec:
+{{- if eq .Values.deployment.type "Deployment" }}
   replicas: {{ .Values.pod.replicas.volume }}
+{{ tuple $envAll | include "helm-toolkit.snippets.kubernetes_upgrades_deployment" | indent 2 }}
+{{- end }}
+{{- if eq .Values.deployment.type "StatefulSet" }}
+  replicas: {{ .Values.pod.replicas.volume }}
+{{ tuple $envAll | include "helm-toolkit.snippets.kubernetes_upgrades_statefulset" | indent 2 }}
+  serviceName: cinder-volume
+{{- end }}
   selector:
     matchLabels:
 {{ tuple $envAll "cinder" "volume" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 6 }}
+{{- if eq .Values.deployment.type "Deployment" }}
 {{ tuple $envAll | include "helm-toolkit.snippets.kubernetes_upgrades_deployment" | indent 2 }}
+{{- else if eq .Values.deployment.type "StatefulSet" }}
+{{ tuple $envAll | include "helm-toolkit.snippets.kubernetes_upgrades_statefulset" | indent 2 }}
+{{- end }}
   template:
     metadata:
       labels:
@@ -68,6 +88,20 @@ spec:
       hostIPC: true
 {{- end }}
       initContainers:
+{{- if eq .Values.deployment.type "StatefulSet" }}
+        - name: cinder-conversion-ownership
+{{ tuple $envAll "cinder_volume" | include "helm-toolkit.snippets.image" | indent 10 }}
+          securityContext:
+            runAsUser: 0
+          command:
+            - chown
+            - -R
+            - "cinder:"
+            - "/var/lib/cinder/conversion"
+          volumeMounts:
+            - name: cinder-conversion-vol
+              mountPath: /var/lib/cinder/conversion
+{{- end }}
 {{ tuple $envAll "volume" $mounts_cinder_volume_init | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
         {{- range $name := rest (splitList "," (include "cinder.utils.ceph_backend_list" $envAll)) }}
           {{- $backend := index $envAll.Values.conf.backends $name }}
@@ -169,8 +203,13 @@ spec:
               readOnly: true
             - name: pod-shared
               mountPath: /tmp/pod-shared
+            {{- if .Values.manifests.pvc_cinder_conversion }}
+            - name: cinder-conversion-vol
+              mountPath: /var/lib/cinder/conversion
+            {{- else }}
             - name: cinder-conversion
               mountPath: /var/lib/cinder/conversion
+            {{- end }}
             - name: cinder-etc
               mountPath: /etc/cinder/cinder.conf
               subPath: cinder.conf
@@ -302,8 +341,14 @@ spec:
             defaultMode: 0444
         - name: pod-shared
           emptyDir: {}
+      {{- if .Values.manifests.pvc_cinder_conversion }}
+        - name: cinder-conversion-vol
+          persistentVolumeClaim:
+            claimName: cinder-conversion-vol
+      {{- else }}
         - name: cinder-conversion
           emptyDir: {}
+      {{- end }}
         {{- if eq "true" (include "cinder.utils.has_ceph_backend" $envAll) }}
         - name: etcceph
           emptyDir: {}
@@ -358,4 +403,15 @@ spec:
 {{- dict "enabled" (or .Values.manifests.certificates .Values.tls.identity) "name" .Values.secrets.tls.volumev3.api.internal | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
 {{- dict "enabled" $envAll.Values.manifests.certificates "name" $envAll.Values.endpoints.oslo_messaging.auth.admin.secret.tls.internal | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
 {{ if $mounts_cinder_volume.volumes }}{{ toYaml $mounts_cinder_volume.volumes | indent 8 }}{{ end }}
+{{- end }}
+{{- if eq .Values.deployment.type "StatefulSet" }}
+  volumeClaimTemplates:
+  - metadata:
+      name: cinder-conversion-vol
+    spec:
+      accessModes: ["{{ .Values.cinder_conversion_volume.access_modes }}"]
+      resources:
+        requests:
+          storage: {{ .Values.cinder_conversion_volume.size }}
+      storageClassName: {{ .Values.cinder_conversion_volume.class_name }}
 {{- end }}

--- a/openstack-helm/cinder/values.yaml
+++ b/openstack-helm/cinder/values.yaml
@@ -16,8 +16,8 @@
 # name: value
 
 ---
+# The deployment type consists of three options: deployment, daemonset, and statefulset.
 deployment:
-  mode: namespace
   type: Deployment
 
 storage: ceph

--- a/openstack-helm/cinder/values.yaml
+++ b/openstack-helm/cinder/values.yaml
@@ -16,6 +16,10 @@
 # name: value
 
 ---
+deployment:
+  mode: namespace
+  type: Deployment
+
 storage: ceph
 
 labels:

--- a/openstack-helm/glance/templates/deployment-api.yaml
+++ b/openstack-helm/glance/templates/deployment-api.yaml
@@ -38,13 +38,8 @@ metadata:
   labels:
 {{ tuple $envAll "glance" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
 spec:
-{{- if eq .Values.deployment.type "Deployment" }}
-  replicas: {{ .Values.pod.replicas.volume }}
-{{ tuple $envAll | include "helm-toolkit.snippets.kubernetes_upgrades_deployment" | indent 2 }}
-{{- end }}
+  replicas: {{ .Values.pod.replicas.api }}
 {{- if eq .Values.deployment.type "StatefulSet" }}
-  replicas: {{ .Values.pod.replicas.volume }}
-{{ tuple $envAll | include "helm-toolkit.snippets.kubernetes_upgrades_statefulset" | indent 2 }}
   serviceName: glance-api
 {{- end }}
   selector:
@@ -83,6 +78,20 @@ spec:
       hostIPC: true
 {{- end }}
       initContainers:
+{{- if or (eq .Values.deployment.type "StatefulSet") (eq .Values.client_tmp_pvc_volume.access_modes "ReadWriteMany") }}
+        - name: nginx-temp-ownership
+{{ tuple $envAll "nginx" | include "helm-toolkit.snippets.image" | indent 10 }}
+          securityContext:
+            runAsUser: 0
+          command:
+            - chown
+            - -R
+            - "nginx:"
+            - "/var/cache/nginx/client_temp"
+          volumeMounts:
+            - name: client-tmp-pvc
+              mountPath: /var/cache/nginx/client_temp
+{{- end }}
 {{ tuple $envAll "api" $mounts_glance_api_init | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
         - name: glance-perms
 {{ tuple $envAll "glance_api" | include "helm-toolkit.snippets.image" | indent 10 }}
@@ -152,7 +161,7 @@ spec:
                   - /tmp/nginx.sh
                   - stop
           volumeMounts:
-           {{- if eq .Values.deployment.type "StatefulSet" }}
+           {{- if or (eq .Values.deployment.type "StatefulSet") (eq .Values.client_tmp_pvc_volume.access_modes "ReadWriteMany") }}
             - name: client-tmp-pvc
               mountPath: /var/cache/nginx/client_temp
               readOnly: false
@@ -391,7 +400,7 @@ spec:
 {{- dict "enabled" $envAll.Values.manifests.certificates "name" $envAll.Values.endpoints.oslo_messaging.auth.admin.secret.tls.internal | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
 {{ if $mounts_glance_api.volumes }}{{ toYaml $mounts_glance_api.volumes | indent 8 }}{{ end }}
 {{- end }}
-{{- if eq .Values.deployment.type "StatefulSet" }}
+{{- if or (eq .Values.deployment.type "StatefulSet") (eq .Values.client_tmp_pvc_volume.access_modes "ReadWriteMany") }}
   volumeClaimTemplates:
   - metadata:
       name: client-tmp-pvc

--- a/openstack-helm/glance/templates/deployment-api.yaml
+++ b/openstack-helm/glance/templates/deployment-api.yaml
@@ -21,8 +21,16 @@ limitations under the License.
 {{- $serviceAccountName := "glance-api" }}
 {{ tuple $envAll "api" $serviceAccountName | include "helm-toolkit.snippets.kubernetes_pod_rbac_serviceaccount" }}
 ---
+{{- if eq .Values.deployment.type "Deployment" }}
 apiVersion: apps/v1
 kind: Deployment
+{{- else if eq .Values.deployment.type "DaemonSet" }}
+apiVersion: apps/v1
+kind: DaemonSet
+{{- else if eq .Values.deployment.type "StatefulSet" }}
+apiVersion: apps/v1
+kind: StatefulSet
+{{- end }}
 metadata:
   name: glance-api
   annotations:
@@ -30,11 +38,23 @@ metadata:
   labels:
 {{ tuple $envAll "glance" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
 spec:
-  replicas: {{ .Values.pod.replicas.api }}
+{{- if eq .Values.deployment.type "Deployment" }}
+  replicas: {{ .Values.pod.replicas.volume }}
+{{ tuple $envAll | include "helm-toolkit.snippets.kubernetes_upgrades_deployment" | indent 2 }}
+{{- end }}
+{{- if eq .Values.deployment.type "StatefulSet" }}
+  replicas: {{ .Values.pod.replicas.volume }}
+{{ tuple $envAll | include "helm-toolkit.snippets.kubernetes_upgrades_statefulset" | indent 2 }}
+  serviceName: glance-api
+{{- end }}
   selector:
     matchLabels:
 {{ tuple $envAll "glance" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 6 }}
+{{- if eq .Values.deployment.type "Deployment" }}
 {{ tuple $envAll | include "helm-toolkit.snippets.kubernetes_upgrades_deployment" | indent 2 }}
+{{- else if eq .Values.deployment.type "StatefulSet" }}
+{{ tuple $envAll | include "helm-toolkit.snippets.kubernetes_upgrades_statefulset" | indent 2 }}
+{{- end }}
   template:
     metadata:
       labels:
@@ -132,6 +152,11 @@ spec:
                   - /tmp/nginx.sh
                   - stop
           volumeMounts:
+           {{- if eq .Values.deployment.type "StatefulSet" }}
+            - name: client-tmp-pvc
+              mountPath: /var/cache/nginx/client_temp
+              readOnly: false
+           {{- end }}
             - name: glance-bin
               mountPath: /tmp/nginx.sh
               subPath: nginx.sh
@@ -366,3 +391,15 @@ spec:
 {{- dict "enabled" $envAll.Values.manifests.certificates "name" $envAll.Values.endpoints.oslo_messaging.auth.admin.secret.tls.internal | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
 {{ if $mounts_glance_api.volumes }}{{ toYaml $mounts_glance_api.volumes | indent 8 }}{{ end }}
 {{- end }}
+{{- if eq .Values.deployment.type "StatefulSet" }}
+  volumeClaimTemplates:
+  - metadata:
+      name: client-tmp-pvc
+    spec:
+      accessModes: ["{{ .Values.client_tmp_pvc_volume.access_modes }}"]
+      resources:
+        requests:
+            storage: {{ .Values.client_tmp_pvc_volume.size }}
+      storageClassName: {{ .Values.client_tmp_pvc_volume.class_name }}
+{{- end }}
+

--- a/openstack-helm/glance/values.yaml
+++ b/openstack-helm/glance/values.yaml
@@ -17,6 +17,7 @@
 
 # radosgw, rbd, swift or pvc
 ---
+# The deployment type consists of three options: deployment, daemonset, and statefulset.
 deployment:
   mode: namespace
   type: Deployment

--- a/openstack-helm/glance/values.yaml
+++ b/openstack-helm/glance/values.yaml
@@ -17,6 +17,10 @@
 
 # radosgw, rbd, swift or pvc
 ---
+deployment:
+  mode: namespace
+  type: Deployment
+
 storage: swift
 
 labels:

--- a/roles/burrito.openstack/templates/osh/cinder.yml.j2
+++ b/roles/burrito.openstack/templates/osh/cinder.yml.j2
@@ -18,6 +18,9 @@ images:
     cinder_backup_storage_init: "{{ docker_image_repo }}/openstackhelm/ceph-config-helper:latest-ubuntu_focal"
     dep_check: "{{ quay_image_repo }}/airshipit/kubernetes-entrypoint:v1.0.0"
 
+deployment:
+  type: StatefulSet
+
 pod:
   security_context:
     cinder_api:
@@ -84,6 +87,11 @@ pod:
     backup: {{ pod.replicas }}
     scheduler: {{ pod.replicas }}
     volume: {{ pod.replicas }}
+
+cinder_conversion_volume:
+  access_modes: "ReadWriteOnce"
+  class_name: "{{ storageclass_name }}"
+  size: "{{ cinder_volume_size }}"
 
 bootstrap:
   volume_types:

--- a/roles/burrito.openstack/templates/osh/cinder.yml.j2
+++ b/roles/burrito.openstack/templates/osh/cinder.yml.j2
@@ -19,7 +19,11 @@ images:
     dep_check: "{{ quay_image_repo }}/airshipit/kubernetes-entrypoint:v1.0.0"
 
 deployment:
+{% if "netapp" in storage_backends %}
+  type: Deployment
+{% else %}
   type: StatefulSet
+{% endif %}
 
 pod:
   security_context:
@@ -89,7 +93,11 @@ pod:
     volume: {{ pod.replicas }}
 
 cinder_conversion_volume:
+{% if "netapp" in storage_backends %}
+  access_modes: "ReadWriteMany"
+{% else %}
   access_modes: "ReadWriteOnce"
+{% endif %}
   class_name: "{{ storageclass_name }}"
   size: "{{ cinder_volume_size }}"
 
@@ -412,4 +420,5 @@ manifests:
   deployment_backup: {{ enable_cinder_backup }}
   job_backup_storage_init: {{ enable_cinder_backup }}
   job_storage_init: {{ ("ceph" in storage_backends)|ternary('true', 'false') }}
+  pvc_cinder_conversion: true
 ...

--- a/roles/burrito.openstack/templates/osh/glance.yml.j2
+++ b/roles/burrito.openstack/templates/osh/glance.yml.j2
@@ -15,6 +15,9 @@ images:
     dep_check: {{ quay_image_repo }}/airshipit/kubernetes-entrypoint:v1.0.0
     rabbit_init: "{{ docker_image_repo }}/library/rabbitmq:3.11-management"
 
+deployment:
+  type: StatefulSet
+
 conf:
 {% if 'ceph' in storage_backends %}
   software:
@@ -144,6 +147,11 @@ storage: "{{ glance.storage }}"
 volume:
   class_name: "{{ storageclass_name }}"
   size: "{{ glance.volume_size }}"
+
+client_tmp_pvc_volume:
+  access_modes: "ReadWriteOnce"
+  class_name: "{{ storageclass_name }}"
+  size: "{{ client_temp_size }}"
 
 bootstrap:
   enabled: false

--- a/roles/burrito.openstack/templates/osh/glance.yml.j2
+++ b/roles/burrito.openstack/templates/osh/glance.yml.j2
@@ -16,7 +16,12 @@ images:
     rabbit_init: "{{ docker_image_repo }}/library/rabbitmq:3.11-management"
 
 deployment:
+{% if "netapp" in storage_backends %}
+  type: Deployment
+{% else %}
   type: StatefulSet
+{% endif %}
+
 
 conf:
 {% if 'ceph' in storage_backends %}
@@ -149,7 +154,11 @@ volume:
   size: "{{ glance.volume_size }}"
 
 client_tmp_pvc_volume:
+{% if "netapp" in storage_backends %}
+  access_modes: "ReadWriteMany"
+{% else %}
   access_modes: "ReadWriteOnce"
+{% endif %}
   class_name: "{{ storageclass_name }}"
   size: "{{ client_temp_size }}"
 

--- a/vars.yml.sample
+++ b/vars.yml.sample
@@ -458,6 +458,7 @@ glance:
     proxy_body_size: "102400M"
     proxy_read_timeout: "3600"
   volume_size: "500Gi"
+client_temp_size: "200Gi"
 
 # placement
 placement:
@@ -512,6 +513,7 @@ cinder:
   enabled_backends: "{{ storage_backends|map('extract', cinder_backends_map)|join(',') }}"
   default_volume_type: "{{ storage_backends|map('extract', cinder_backends_map)|first }}"
   password: "{{ vault_cinder_password }}"
+cinder_volume_size: "100Gi"
 
 # horizon
 horizon:


### PR DESCRIPTION
cinder와 glance의 values.yml에서 deployment mode를 삭제, 이후 type을 어떤 type을 사용할 수 있는지 수정하였습니다.
backend sotrage가 "netapp"일 경우, deployment로 배포되도록 수정하였습니다.
해당 변수는 cinderyml.j2, glance.yaml.j2파일에서 backend storage 변수로 deployment인지 구분할 수 있도록하였으며,
추가로 pvc나 ownership, mount등 netapp을 netapp을 구분할 수 있도록 netapp의 access_mode인 ReadWriteMany일 경우를 변수로 넣었습니다.

확인부탁드립니다.
감사합니다.