### PR TITLE
fix: remove btx in bashrc when clean_openstack.sh script runs

### DIFF
--- a/scripts/clean_openstack.sh
+++ b/scripts/clean_openstack.sh
@@ -43,3 +43,9 @@ sudo kubectl delete configmap --all -n openstack ${KUBECTL_PARAM}
 sudo kubectl delete secret --all -n openstack ${KUBECTL_PARAM}
 sudo kubectl delete jobs --all -n openstack ${KUBECTL_PARAM}
 sudo kubectl delete pods --all -n openstack ${KUBECTL_PARAM}
+
+# Remove btx block in bashrc
+source ~/.envs/burrito/bin/activate && \
+  ansible kube_control_plane -m ansible.builtin.blockinfile \
+    -a "path=/home/$USER/.bashrc marker='# {mark} BTX ENV BLOCK' state=absent"
+


### PR DESCRIPTION
fix: remove btx in bashrc when clean_openstack.sh script runs