### PR TITLE
fix(openstack): vnc listens on management interface only

### DIFF
--- a/openstack-helm/nova/templates/bin/_nova-console-compute-init.sh.tpl
+++ b/openstack-helm/nova/templates/bin/_nova-console-compute-init.sh.tpl
@@ -53,7 +53,7 @@ if [ "${console_kind}" == "novnc" ] ; then
   cat > /tmp/pod-shared/nova-console.conf <<EOF
 [vnc]
 server_proxyclient_address = $client_address
-vncserver_listen = $listen_ip
+server_listen = $client_address
 EOF
 elif [ "${console_kind}" == "spice" ] ; then
   cat > /tmp/pod-shared/nova-console.conf <<EOF


### PR DESCRIPTION
fix(openstack): vnc listens on management interface only