### PR TITLE
fix: add the default containerd_registries_mirrors in vars.yml.sample

### DIFF
--- a/vars.yml.sample
+++ b/vars.yml.sample
@@ -375,12 +375,13 @@ registry_disk_size: "30Gi"
 registry_service_type: "NodePort"
 registry_service_nodeport: "32680"
 seed_registry_port: "5000"
-containerd_insecure_registries: >-
-  {% if registry_enabled -%}
-  {"local_registry": "{{ keepalived_vip }}:{{ registry_service_nodeport }}"}
-  {% else -%}
-  {}
-  {% endif -%}
+containerd_registries_mirrors:
+  - prefix: docker.io
+    protocol: "https"
+    mirrors:
+      - host: https://registry-1.docker.io
+        capabilities: ["pull", "resolve"]
+        skip_verify: false
 
 metallb_config:
   controller:


### PR DESCRIPTION
fix: add the default containerd_registries_mirrors in vars.yml.sample