### PR TITLE
fix(gnsh): do not run gnsh role when there is only one control node

### DIFF
--- a/landing.yml
+++ b/landing.yml
@@ -20,5 +20,6 @@
   any_errors_fatal: true
   roles:
     - role: burrito.gnsh
+      when: groups['kube_control_plane']|length > 1
       tags: ['gnsh', 'burrito']
 ...


### PR DESCRIPTION
fix(gnsh): do not run gnsh role when there is only one control node