### PR TITLE
Fix openstack configuration

### DIFF
--- a/openstack-helm/cinder/templates/bin/_cinder-scheduler.sh.tpl
+++ b/openstack-helm/cinder/templates/bin/_cinder-scheduler.sh.tpl
@@ -15,5 +15,13 @@ limitations under the License.
 */}}
 
 set -ex
+
+# override heartbeat_in_pthread variable
+tee > /tmp/oslo_messaging_rabbit.conf << EOF
+[oslo_messaging_rabbit]
+heartbeat_in_pthread = false
+EOF
+
 exec cinder-scheduler \
-      --config-file /etc/cinder/cinder.conf
+      --config-file /etc/cinder/cinder.conf \
+      --config-file /tmp/oslo_messaging_rabbit.conf

--- a/openstack-helm/cinder/templates/bin/_cinder-volume.sh.tpl
+++ b/openstack-helm/cinder/templates/bin/_cinder-volume.sh.tpl
@@ -29,7 +29,14 @@ set -ex
   {{- end }}
 {{- end }}
 
+# override heartbeat_in_pthread variable
+tee > /tmp/oslo_messaging_rabbit.conf << EOF
+[oslo_messaging_rabbit]
+heartbeat_in_pthread = false
+EOF
+
 exec cinder-volume \
      --config-file /etc/cinder/cinder.conf \
+     --config-file /tmp/oslo_messaging_rabbit.conf \
      --config-file /etc/cinder/conf/backends.conf \
      --config-file /tmp/pod-shared/internal_tenant.conf

--- a/openstack-helm/nova/templates/bin/_nova-compute.sh.tpl
+++ b/openstack-helm/nova/templates/bin/_nova-compute.sh.tpl
@@ -16,8 +16,15 @@ limitations under the License.
 
 set -ex
 
+# override heartbeat_in_pthread variable
+tee > /tmp/oslo_messaging_rabbit.conf << EOF
+[oslo_messaging_rabbit]
+heartbeat_in_pthread = false
+EOF
+
 exec nova-compute \
       --config-file /etc/nova/nova.conf \
+      --config-file /tmp/oslo_messaging_rabbit.conf \
 {{- if .Values.console.address_search_enabled }}
       --config-file /tmp/pod-shared/nova-console.conf \
 {{- end }}

--- a/openstack-helm/nova/templates/bin/_nova-conductor.sh.tpl
+++ b/openstack-helm/nova/templates/bin/_nova-conductor.sh.tpl
@@ -15,5 +15,13 @@ limitations under the License.
 */}}
 
 set -x
+
+# override heartbeat_in_pthread variable
+tee > /tmp/oslo_messaging_rabbit.conf << EOF
+[oslo_messaging_rabbit]
+heartbeat_in_pthread = false
+EOF
+
 exec nova-conductor \
-      --config-file /etc/nova/nova.conf
+      --config-file /etc/nova/nova.conf \
+      --config-file /tmp/oslo_messaging_rabbit.conf

--- a/openstack-helm/nova/templates/bin/_nova-scheduler.sh.tpl
+++ b/openstack-helm/nova/templates/bin/_nova-scheduler.sh.tpl
@@ -16,5 +16,12 @@ limitations under the License.
 
 set -xe
 
+# override heartbeat_in_pthread variable
+tee > /tmp/oslo_messaging_rabbit.conf << EOF
+[oslo_messaging_rabbit]
+heartbeat_in_pthread = false
+EOF
+
 exec nova-scheduler \
-      --config-file /etc/nova/nova.conf
+      --config-file /etc/nova/nova.conf \
+      --config-file /tmp/oslo_messaging_rabbit.conf

--- a/roles/burrito.localrepo/defaults/main.yml
+++ b/roles/burrito.localrepo/defaults/main.yml
@@ -14,9 +14,9 @@ localrepo:
 docker_image_repo: ~
 
 files_src: "/mnt/files"
-files_dst: "/usr/share/nginx/html/files"
+files_dst: "/usr/share/nginx/html/"
 pkg_src: "/mnt/BaseOS"
-pkg_dst: "/usr/share/nginx/html/BaseOS"
+pkg_dst: "/usr/share/nginx/html/"
 keepalived_vip: ~
 balance: roundrobin
 inter: 2s

--- a/roles/burrito.netapp/tasks/main.yml
+++ b/roles/burrito.netapp/tasks/main.yml
@@ -19,6 +19,13 @@
   delegate_to: localhost
   run_once: true
 
+- name: netapp | remove netapp artifacts directory
+  ansible.builtin.file:
+    path: "{{ artifacts_dir }}"
+    state: absent
+  delegate_to: localhost
+  run_once: true
+
 - name: netapp | create netapp artifacts directory
   ansible.builtin.file:
     path: "{{ artifacts_dir }}/setup"

--- a/roles/burrito.openstack/templates/osh/nova.yml.j2
+++ b/roles/burrito.openstack/templates/osh/nova.yml.j2
@@ -220,7 +220,7 @@ conf:
       vencrypt_ca_certs: /etc/pki/nova-novncproxy/ca-cert.pem
       novncproxy_base_url: https://{{ keepalived_vip_svc|ternary(keepalived_vip_svc, keepalived_vip) }}:30608/vnc_auto.html
     libvirt:
-      volume_use_multipath: {{ enable_iscsi }}
+      volume_use_multipath: {{ enable_multipath }}
       connection_uri: "qemu+tcp://127.0.0.1/system"
       images_type: {{ (storage_backends[0] == 'ceph')|ternary('rbd', 'qcow2') }}
 {% if "ceph" in storage_backends %}

--- a/roles/burrito.openstack/templates/osh/nova.yml.j2
+++ b/roles/burrito.openstack/templates/osh/nova.yml.j2
@@ -199,11 +199,10 @@ conf:
       block_device_allocate_retries_interval: 10
       vif_plugging_timeout: 1200
       allow_resize_to_same_host: true
-      notification_format: versioned
     devices:
       enabled_vgpu_types: 
     notifications:
-      bdms_in_notifications: true
+      notification_format: versioned
     service_user:
       send_service_user_token: true
       auth_type: password
@@ -238,7 +237,7 @@ conf:
     filter_scheduler:
       ram_weight_multiplier: 4.0
       available_filters: nova.scheduler.filters.all_filters
-      enabled_filters: AvailabilityZoneFilter, ComputeFilter, ComputeCapabilitiesFilter, ImagePropertiesFilter, ServerGroupAntiAffinityFilter, ServerGroupAffinityFilter
+      enabled_filters: ComputeFilter, ComputeCapabilitiesFilter, ImagePropertiesFilter, ServerGroupAntiAffinityFilter, ServerGroupAffinityFilter
     quota:
       instances: -1
       cores: -1

--- a/scripts/images.txt
+++ b/scripts/images.txt
@@ -1,6 +1,6 @@
 docker.io/jijisa/asklepios:0.2.0
 docker.io/jijisa/barbican:2023.1-ubuntu_jammy
-docker.io/jijisa/btx:2.0.1
+docker.io/jijisa/btx:2.0.2
 docker.io/jijisa/cinder:2023.1-ubuntu_jammy
 docker.io/jijisa/glance:2023.1-ubuntu_jammy
 docker.io/jijisa/heat:2023.1-ubuntu_jammy

--- a/vars.yml.sample
+++ b/vars.yml.sample
@@ -261,7 +261,7 @@ preinstall_selinux_state: disabled
 sysctl_file_path: "/etc/sysctl.d/10-k8s.conf"
 
 # ipam settings for kubernetes
-kube_pods_subnet: 10.200.0.0/13
+kube_pods_subnet: 10.233.64.0/18
 kube_network_node_prefix: 24
 kubelet_max_pods: 250
 

--- a/vars.yml.sample
+++ b/vars.yml.sample
@@ -406,6 +406,9 @@ csi_resizer_version: "v1.9.0"
 csi_snapshotter_version: "v6.3.0"
 registry_ready_timeout: 300
 
+# burrito.netapp role variables
+trident_version: "24.02.0"
+
 # burrito.powerflex role variables
 pfx_version: "v2.6.0"
 pfx_snapshot_controller_version: "v6.2.1"

--- a/vars.yml.sample
+++ b/vars.yml.sample
@@ -450,6 +450,13 @@ enable_iscsi_map:
   hitachi: true
   primera: true
 enable_iscsi: "{{ storage_backends|map('extract', enable_iscsi_map)|list is any }}"
+enable_multipath_map:
+  ceph: false
+  netapp: false
+  powerflex: false
+  hitachi: true
+  primera: true
+enable_multipath: "{{ storage_backends|map('extract', enable_multipath_map)|list is all }}"
 
 # keystone
 os_admin_password: "{{ vault_openstack_admin_password }}"

--- a/vars.yml.sample
+++ b/vars.yml.sample
@@ -593,7 +593,7 @@ barbican:
 
 ### btx
 btx:
-  version: "2.0.1"
+  version: "2.0.2"
   pvc:
     size: "200Gi"
 


### PR DESCRIPTION
* override heartbeat_in_pthread to false in cinder-scheduler and cinder-volume; (jijisa@iorchard.net)
* fix(openstack): override heartbeat_in_pthread to false for nova-{compute,conductor,scheduler}; (jijisa@iorchard.net)
* Moved `notification_format: versioned` to notifications from DEFAULT. ; Removed `bdms_in_notifications: true` in notifications section. ; Removed AvailabilityZoneFilter from enabled_filters which is deprecated.; (jijisa@iorchard.net)
* changed kube_pods_subnet to the default value - 10.233.64.0/18; (jijisa@iorchard.net)
