### PR TITLE
include missing commit for powerflex

### DIFF
--- a/scripts/pfx_images.txt
+++ b/scripts/pfx_images.txt
@@ -1,2 +1,2 @@
-docker.io/dellemc/csi-vxflexos:v2.6.0
+docker.io/dellemc/csi-vxflexos:v2.11.0
 registry.k8s.io/sig-storage/snapshot-controller:v6.2.1

--- a/vars.yml.sample
+++ b/vars.yml.sample
@@ -435,7 +435,7 @@ registry_ready_timeout: 300
 trident_version: "24.02.0"
 
 # burrito.powerflex role variables
-pfx_version: "v2.6.0"
+pfx_version: "v2.11.0"
 pfx_snapshot_controller_version: "v6.2.1"
 
 # burrito.openstack role variables
@@ -497,7 +497,7 @@ keystone:
 glance_store_types:
   ceph: 'rbd'
   netapp: 'cinder'
-  powerflex: 'cinder'
+  powerflex: 'file'
   hitachi: 'cinder'
   primera: 'cinder'
   lvm: 'cinder'
@@ -505,7 +505,7 @@ glance_store_types:
 glance_storage:
   ceph: 'rbd'
   netapp: 'cinder'
-  powerflex: 'cinder'
+  powerflex: 'file'
   hitachi: 'cinder'
   primera: 'cinder'
   lvm: 'cinder'


### PR DESCRIPTION
- upgrade csi-vxflexos to v2.11.0 which supports k8s v1.30.x
- Change powerflex glance store to file due to the bug (see https://bugs.launchpad.net/cinder/+bug/2068548)
