### PR TITLE
fix/openstack/novnc proxy vnc console error

### DIFF
--- a/roles/burrito.openstack/templates/osh/nova.yml.j2
+++ b/roles/burrito.openstack/templates/osh/nova.yml.j2
@@ -225,9 +225,6 @@ conf:
       password: {{ nova.password }}
     vnc:
       auth_schemes: vencrypt
-      #vencrypt_client_key: /etc/pki/nova-novncproxy/client-key.pem
-      #vencrypt_client_cert: /etc/pki/nova-novncproxy/client-cert.pem
-      #vencrypt_ca_certs: /etc/pki/nova-novncproxy/ca-cert.pem
       novncproxy_base_url: https://{{ keepalived_vip_svc|ternary(keepalived_vip_svc, keepalived_vip) }}:30608/vnc_auto.html
     libvirt:
       volume_use_multipath: {{ enable_multipath }}
@@ -393,6 +390,9 @@ endpoints:
       default:
         tls:
           secretName: nova-novncproxy-vencrypt
+          commonName: nova-novncproxy
+          usages:
+            - client auth
           duration: {{ tls.duration }}
           renewBefore: {{ tls.renewBefore }}
           issuerRef:

--- a/roles/burrito.openstack/templates/osh_infra/libvirt.yml.j2
+++ b/roles/burrito.openstack/templates/osh_infra/libvirt.yml.j2
@@ -31,54 +31,6 @@ conf:
     issuer:
       kind: ClusterIssuer
       name: ca-issuer
-    cert_init_sh: |
-      #!/bin/bash
-      set -x
-
-      HOSTNAME_FQDN=$(hostname --fqdn)
-
-      # Script to create certs for each libvirt pod based on pod IP (by default).
-      cat <<EOF | kubectl apply -f -
-      apiVersion: cert-manager.io/v1
-      kind: Certificate
-      metadata:
-        name: ${POD_NAME}-${TYPE}
-        namespace: ${POD_NAMESPACE}
-        ownerReferences:
-          - apiVersion: v1
-            kind: Pod
-            name: ${POD_NAME}
-            uid: ${POD_UID}
-      spec:
-        secretName: ${POD_NAME}-${TYPE}
-        commonName: ${POD_IP}
-        duration: {{ tls.duration }}
-        renewBefore: {{ tls.renewBefore }}
-        usages:
-        - client auth
-        - server auth
-        dnsNames:
-        - ${HOSTNAME}
-        - ${HOSTNAME_FQDN}
-        ipAddresses:
-        - ${POD_IP}
-        issuerRef:
-          kind: ${ISSUER_KIND}
-          name: ${ISSUER_NAME}
-      EOF
-
-      kubectl -n ${POD_NAMESPACE} wait --for=condition=Ready --timeout=300s \
-        certificate/${POD_NAME}-${TYPE}
-
-      # NOTE(mnaser): cert-manager does not clean-up the secrets when the certificate
-      #               is deleted, so we should add an owner reference to the secret
-      #               to ensure that it is cleaned up when the pod is deleted.
-      kubectl -n ${POD_NAMESPACE} patch secret ${POD_NAME}-${TYPE} \
-        --type=json -p='[{"op": "add", "path": "/metadata/ownerReferences", "value": [{"apiVersion": "v1", "kind": "Pod", "name": "'${POD_NAME}'", "uid": "'${POD_UID}'"}]}]'
-
-      kubectl -n ${POD_NAMESPACE} get secret ${POD_NAME}-${TYPE} -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/${TYPE}.crt
-      kubectl -n ${POD_NAMESPACE} get secret ${POD_NAME}-${TYPE} -o jsonpath='{.data.tls\.key}' | base64 -d > /tmp/${TYPE}.key
-      kubectl -n ${POD_NAMESPACE} get secret ${POD_NAME}-${TYPE} -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/${TYPE}-ca.crt
 
 manifests:
   role_cert_manager: true


### PR DESCRIPTION
- openstack(nova): add commonName and usages in novnc-proxy-vencrypt certificate
- openstack(nova): remove cert_init.sh in nova.yml.j2 which is the same with the default values.yaml
