### PR TITLE
fix/openstack/horizon csrf token missing

### DIFF
--- a/roles/burrito.openstack/templates/osh/glance.yml.j2
+++ b/roles/burrito.openstack/templates/osh/glance.yml.j2
@@ -230,8 +230,8 @@ endpoints:
       public: https
     port:
       web:
-        default: 80
-        public: 443
+        default: 443
+        public: 8443
   oslo_db:
     auth:
       admin:

--- a/roles/burrito.openstack/templates/osh/horizon.yml.j2
+++ b/roles/burrito.openstack/templates/osh/horizon.yml.j2
@@ -92,7 +92,7 @@ conf:
       config:
         use_ssl: "True"
         csrf_cookie_secure: "True"
-        csrf_cookie_httponly: "True"
+        csrf_cookie_httponly: "False"
         enforce_password_check: "True"
         session_cookie_secure: "True"
         session_cookie_httponly: "True"


### PR DESCRIPTION
- fix(glance): cors.allowed_origin in glance-api.conf
- horizon: set CSRF_COOKIE_HTTPONLY to False in local_settings to fix csrf missing token error
