### PR TITLE
feature/storage/upgrade ceph csi

### DIFF
--- a/checklist.yml
+++ b/checklist.yml
@@ -419,6 +419,7 @@
         timeout: 3
         status_code: 200
       loop: "{{ powerstore }}"
+      no_log: true
       when:
         - "'powerstore' in storage_backends"
         - inventory_hostname in groups['kube_node']

--- a/roles/burrito.ceph-csi/defaults/main.yml
+++ b/roles/burrito.ceph-csi/defaults/main.yml
@@ -26,12 +26,10 @@ manifest_files:
   - "{{ artifacts_dir }}/08-csi-rbd-sc.yml"
 
 # container image versions
-cephcsi_version: "v3.10.1"
-csi_attacher_version: "v4.4.0"
-csi_node_driver_registrar_version: "v2.9.0"
-csi_provisioner_version: "v3.6.0"
-csi_resizer_version: "v1.9.0"
-csi_snapshotter_version: "v6.3.0"
-# wait timeout for registry in seconds (default: 300s = 5m)
-registry_ready_timeout: 300
+cephcsi_version: "v3.14.2"
+csi_attacher_version: "v4.9.0"
+csi_node_driver_registrar_version: "v2.14.0"
+csi_provisioner_version: "v5.3.0"
+csi_resizer_version: "v1.14.0"
+csi_snapshotter_version: "v8.3.0"
 ...

--- a/roles/burrito.ceph-csi/files/04-csi-provisioner-rbac.yaml
+++ b/roles/burrito.ceph-csi/files/04-csi-provisioner-rbac.yaml
@@ -34,7 +34,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list", "patch"]
+    verbs: ["get", "list", "watch", "update", "patch", "create"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
     verbs: ["get", "list", "patch"]
@@ -65,10 +65,21 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
     verbs: ["create"]
-  - apiGroups: ["policy"]
-    resources: ["podsecuritypolicies"]
-    verbs: ["use"]
-    resourceNames: ["privileged"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotcontents"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotcontents/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["replication.storage.openshift.io"]
+    resources: ["volumegroupreplicationcontents"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["replication.storage.openshift.io"]
+    resources: ["volumegroupreplicationclasses"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -87,8 +98,8 @@ roleRef:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: rbd-external-provisioner-cfg
   namespace: ceph-csi
+  name: rbd-external-provisioner-cfg
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -96,10 +107,6 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
-  - apiGroups: ["policy"]
-    resources: ["podsecuritypolicies"]
-    verbs: ["use"]
-    resourceNames: ["privileged"]
 
 ---
 kind: RoleBinding

--- a/roles/burrito.ceph-csi/files/05-csi-nodeplugin-rbac.yaml
+++ b/roles/burrito.ceph-csi/files/05-csi-nodeplugin-rbac.yaml
@@ -32,10 +32,6 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
     verbs: ["create"]
-  - apiGroups: ["policy"]
-    resources: ["podsecuritypolicies"]
-    verbs: ["use"]
-    resourceNames: ["privileged"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/roles/burrito.ceph-csi/tasks/main.yml
+++ b/roles/burrito.ceph-csi/tasks/main.yml
@@ -65,36 +65,4 @@
     wait_timeout: 300
   loop: "{{ manifest_files }}"
   become: true
-
-- name: ceph-csi | set auth_client_required to cephx
-  ansible.builtin.command: >-
-    ceph config set mon auth_client_required cephx
-  become: true
-  delegate_to: localhost
-  run_once: true
-
-- name: ceph-csi | wait until registry is running.
-  kubernetes.core.k8s_info:
-    kind: Pod
-    label_selectors:
-      - k8s-app = registry
-    namespace: kube-system
-    wait: true
-    wait_sleep: 5
-    wait_timeout: "{{ registry_ready_timeout }}"
-  become: true
-  register: registry_pod
-  when:
-    - storage_backends[0] == 'ceph'
-    - registry_enabled
-
-- name: ceph-csi | fail if registry is not running
-  ansible.builtin.fail:
-    msg: >-
-      Registry is not running after {{ registry_ready_timeout }} seconds.
-      Give up!
-  when:
-    - storage_backends[0] == 'ceph'
-    - registry_enabled
-    - registry_pod.resources[0].status.phase != 'Running'
 ...

--- a/roles/burrito.ceph-csi/templates/06-csi-rbdplugin-provisioner.yaml.j2
+++ b/roles/burrito.ceph-csi/templates/06-csi-rbdplugin-provisioner.yaml.j2
@@ -51,77 +51,7 @@ spec:
       serviceAccountName: rbd-csi-provisioner
       priorityClassName: system-cluster-critical
       containers:
-        - name: csi-provisioner
-          image: {{ kube_image_repo }}/sig-storage/csi-provisioner:{{ csi_provisioner_version }}
-          args:
-            - "--csi-address=$(ADDRESS)"
-            - "--v=1"
-            - "--timeout=150s"
-            - "--retry-interval-start=500ms"
-            - "--leader-election=true"
-            #  set it to true to use topology based provisioning
-            - "--feature-gates=Topology=false"
-            - "--feature-gates=HonorPVReclaimPolicy=true"
-            - "--prevent-volume-mode-conversion=true"
-            # if fstype is not specified in storageclass, ext4 is default
-            - "--default-fstype=ext4"
-            - "--extra-create-metadata=true"
-          env:
-            - name: ADDRESS
-              value: unix:///csi/csi-provisioner.sock
-          imagePullPolicy: "IfNotPresent"
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
-        - name: csi-snapshotter
-          image: {{ kube_image_repo }}/sig-storage/csi-snapshotter:{{ csi_snapshotter_version }}
-          args:
-            - "--csi-address=$(ADDRESS)"
-            - "--v=1"
-            - "--timeout=150s"
-            - "--leader-election=true"
-            - "--extra-create-metadata=true"
-          env:
-            - name: ADDRESS
-              value: unix:///csi/csi-provisioner.sock
-          imagePullPolicy: "IfNotPresent"
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
-        - name: csi-attacher
-          image: {{ kube_image_repo }}/sig-storage/csi-attacher:{{ csi_attacher_version }}
-          args:
-            - "--v=1"
-            - "--csi-address=$(ADDRESS)"
-            - "--leader-election=true"
-            - "--retry-interval-start=500ms"
-            - "--default-fstype=ext4"
-          env:
-            - name: ADDRESS
-              value: /csi/csi-provisioner.sock
-          imagePullPolicy: "IfNotPresent"
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
-        - name: csi-resizer
-          image: {{ kube_image_repo }}/sig-storage/csi-resizer:{{ csi_resizer_version }}
-          args:
-            - "--csi-address=$(ADDRESS)"
-            - "--v=1"
-            - "--timeout=150s"
-            - "--leader-election"
-            - "--retry-interval-start=500ms"
-            - "--handle-volume-inuse-error=false"
-            - "--feature-gates=RecoverVolumeExpansionFailure=true"
-          env:
-            - name: ADDRESS
-              value: unix:///csi/csi-provisioner.sock
-          imagePullPolicy: "IfNotPresent"
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
         - name: csi-rbdplugin
-          # for stable functionality replace canary with latest release version
           image: {{ quay_image_repo }}/cephcsi/cephcsi:{{ cephcsi_version }}
           args:
             - "--nodeid=$(NODE_ID)"
@@ -177,8 +107,112 @@ spec:
             - name: oidc-token
               mountPath: /run/secrets/tokens
               readOnly: true
+        - name: csi-provisioner
+          image: {{ kube_image_repo }}/sig-storage/csi-provisioner:{{ csi_provisioner_version }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=1"
+            - "--timeout=150s"
+            - "--retry-interval-start=500ms"
+            - "--leader-election=true"
+            - "--feature-gates=HonorPVReclaimPolicy=true"
+            - "--prevent-volume-mode-conversion=true"
+            # if fstype is not specified in storageclass, ext4 is default
+            - "--default-fstype=ext4"
+            - "--extra-create-metadata=true"
+            - "--immediate-topology=false"
+            - "--http-endpoint=$(POD_IP):8090"
+          env:
+            - name: ADDRESS
+              value: unix:///csi/csi-provisioner.sock
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 8090
+              name: http-endpoint
+              protocol: TCP
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-snapshotter
+          image: {{ kube_image_repo }}/sig-storage/csi-snapshotter:{{ csi_snapshotter_version }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=1"
+            - "--timeout=150s"
+            - "--leader-election=true"
+            - "--extra-create-metadata=true"
+            - "--feature-gates=CSIVolumeGroupSnapshot=true"
+            - "--http-endpoint=$(POD_IP):8092"
+          env:
+            - name: ADDRESS
+              value: unix:///csi/csi-provisioner.sock
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 8092
+              name: http-endpoint
+              protocol: TCP
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-attacher
+          image: {{ kube_image_repo }}/sig-storage/csi-attacher:{{ csi_attacher_version }}
+          args:
+            - "--v=1"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election=true"
+            - "--retry-interval-start=500ms"
+            - "--default-fstype=ext4"
+            - "--http-endpoint=$(POD_IP):8093"
+          env:
+            - name: ADDRESS
+              value: /csi/csi-provisioner.sock
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 8093
+              name: http-endpoint
+              protocol: TCP
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-resizer
+          image: {{ kube_image_repo }}/sig-storage/csi-resizer:{{ csi_resizer_version }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=1"
+            - "--timeout=150s"
+            - "--leader-election"
+            - "--retry-interval-start=500ms"
+            - "--handle-volume-inuse-error=false"
+            - "--feature-gates=RecoverVolumeExpansionFailure=true"
+            - "--http-endpoint=$(POD_IP):8091"
+          env:
+            - name: ADDRESS
+              value: unix:///csi/csi-provisioner.sock
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 8091
+              name: http-endpoint
+              protocol: TCP
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
         - name: csi-rbdplugin-controller
-          # for stable functionality replace canary with latest release version
           image: {{ quay_image_repo }}/cephcsi/cephcsi:{{ cephcsi_version }}
           args:
             - "--type=controller"
@@ -215,6 +249,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+          ports:
+            - containerPort: 8680
+              name: http-metrics
+              protocol: TCP
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/roles/burrito.ceph-csi/templates/07-csi-rbdplugin.yaml.j2
+++ b/roles/burrito.ceph-csi/templates/07-csi-rbdplugin.yaml.j2
@@ -21,35 +21,12 @@ spec:
       # resolved through k8s service, set dns policy to cluster first
       dnsPolicy: ClusterFirstWithHostNet
       containers:
-        - name: driver-registrar
-          # This is necessary only for systems with SELinux, where
-          # non-privileged sidecar containers cannot access unix domain socket
-          # created by privileged CSI driver container.
-          securityContext:
-            privileged: true
-            allowPrivilegeEscalation: true
-          image: {{ kube_image_repo }}/sig-storage/csi-node-driver-registrar:{{ csi_node_driver_registrar_version }}
-          args:
-            - "--v=1"
-            - "--csi-address=/csi/csi.sock"
-            - "--kubelet-registration-path=/var/lib/kubelet/plugins/rbd.csi.ceph.com/csi.sock"
-          env:
-            - name: KUBE_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
-            - name: registration-dir
-              mountPath: /registration
         - name: csi-rbdplugin
           securityContext:
             privileged: true
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          # for stable functionality replace canary with latest release version
           image: {{ quay_image_repo }}/cephcsi/cephcsi:{{ cephcsi_version }}
           args:
             - "--nodeid=$(NODE_ID)"
@@ -67,6 +44,15 @@ spec:
             # and pass the label names below, for CSI to consume and advertise
             # its equivalent topology domain
             # - "--domainlabels=failure-domain/region,failure-domain/zone"
+            #
+            # Options to enable read affinity.
+            # If enabled Ceph CSI will fetch labels from kubernetes node and
+            # pass `read_from_replica=localize,crush_location=type:value` during
+            # rbd map command. refer:
+            # https://docs.ceph.com/en/latest/man/8/rbd/#kernel-rbd-krbd-options
+            # for more details.
+            # - "--enable-read-affinity=true"
+            # - "--crush-location-labels=topology.io/zone,topology.io/rack"
           env:
             - name: POD_IP
               valueFrom:
@@ -121,6 +107,28 @@ spec:
             - name: oidc-token
               mountPath: /run/secrets/tokens
               readOnly: true
+        - name: driver-registrar
+          # This is necessary only for systems with SELinux, where
+          # non-privileged sidecar containers cannot access unix domain socket
+          # created by privileged CSI driver container.
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+          image: {{ kube_image_repo }}/sig-storage/csi-node-driver-registrar:{{ csi_node_driver_registrar_version }}
+          args:
+            - "--v=1"
+            - "--csi-address=/csi/csi.sock"
+            - "--kubelet-registration-path=/var/lib/kubelet/plugins/rbd.csi.ceph.com/csi.sock"
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
         - name: liveness-prometheus
           securityContext:
             privileged: true

--- a/roles/burrito.ceph/tasks/init.yml
+++ b/roles/burrito.ceph/tasks/init.yml
@@ -36,4 +36,11 @@
   delegate_to: "{{ groups['mons'][0] }}"
   run_once: true
   loop: "{{ ceph_keys }}"
+
+- name: init | set auth_client_required to cephx
+  ansible.builtin.command: >-
+    ceph config set mon auth_client_required cephx
+  become: true
+  delegate_to: "{{ groups['mons'][0] }}"
+  run_once: true
 ...

--- a/roles/burrito.ceph/tasks/purge.yml
+++ b/roles/burrito.ceph/tasks/purge.yml
@@ -4,7 +4,9 @@
 
 - name: Purge | check if ceph cluster is accessible
   ansible.builtin.shell: >-
-    cephadm --timeout=3 shell -- ceph fsid
+    cephadm --timeout=3 \
+      --image {{ quay_image_repo }}/ceph/ceph:{{ ceph_version }} shell -- \
+      ceph fsid
   become: true
   register: _res
   delegate_to: "{{ groups['mons'][0] }}"
@@ -36,14 +38,18 @@
 
 - name: Purge | disable cephadm mgr module
   ansible.builtin.shell: >-
-    cephadm --timeout=5 shell -- ceph mgr module disable cephadm
+    cephadm --timeout=5 \
+      --image {{ quay_image_repo }}/ceph/ceph:{{ ceph_version }} shell -- \
+      ceph mgr module disable cephadm
   become: true
   delegate_to: "{{ groups['mons'][0] }}"
   run_once: true
   
 - name: Purge | purge the ceph cluster
   ansible.builtin.shell: >-
-    cephadm rm-cluster --force --zap-osds --fsid {{ _fsid }}
+    cephadm \
+      --image {{ quay_image_repo }}/ceph/ceph:{{ ceph_version }} \
+      rm-cluster --force --zap-osds --fsid {{ _fsid }}
   become: true
   when: inventory_hostname in groups['ceph_servers']
 

--- a/roles/burrito.genesisregistry/tasks/netapp_patch.yml
+++ b/roles/burrito.genesisregistry/tasks/netapp_patch.yml
@@ -3,7 +3,7 @@
   kubernetes.core.k8s_json_patch:
     kind: DaemonSet
     namespace: trident
-    name: trident-csi
+    name: trident-node-linux
     patch: "{{ trident_daemonset_patch_list }}"
   become: true
   delegate_to: localhost
@@ -13,7 +13,7 @@
   kubernetes.core.k8s_json_patch:
     kind: Deployment
     namespace: trident
-    name: trident-csi
+    name: trident-controller
     patch: "{{ trident_deploy_patch_list }}"
   become: true
   delegate_to: localhost

--- a/scripts/images.txt
+++ b/scripts/images.txt
@@ -26,7 +26,7 @@ quay.io/calico/cni:v3.29.3
 quay.io/calico/kube-controllers:v3.29.3
 quay.io/calico/node:v3.29.3
 quay.io/ceph/ceph:v19.2.2
-quay.io/cephcsi/cephcsi:v3.10.1
+quay.io/cephcsi/cephcsi:v3.14.2
 quay.io/jetstack/cert-manager-cainjector:v1.15.3
 quay.io/jetstack/cert-manager-controller:v1.15.3
 quay.io/jetstack/cert-manager-webhook:v1.15.3
@@ -44,8 +44,8 @@ registry.k8s.io/kube-proxy:v1.32.5
 registry.k8s.io/kube-scheduler:v1.32.5
 registry.k8s.io/metrics-server/metrics-server:v0.7.0
 registry.k8s.io/pause:3.10
-registry.k8s.io/sig-storage/csi-attacher:v4.6.1
-registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
-registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
-registry.k8s.io/sig-storage/csi-resizer:v1.11.1
-registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
+registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0

--- a/storage.yml
+++ b/storage.yml
@@ -65,4 +65,30 @@
     - role: burrito.powerstore
       when: '"powerstore" in storage_backends'
       tags: ['powerstore']
+
+- name: wait until registry is running.
+  hosts: localhost
+  any_errors_fatal: true
+  tasks:
+    - name: get registry pod info
+      kubernetes.core.k8s_info:
+        kind: Pod
+        label_selectors:
+          - k8s-app = registry
+        namespace: kube-system
+        wait: true
+        wait_sleep: 5
+        wait_timeout: "{{ registry_ready_timeout }}"
+      become: true
+      register: registry_pod
+      when:
+        - registry_enabled
+    - name: fail if registry is not running
+      ansible.builtin.fail:
+        msg: >-
+          Registry is not running after {{ registry_ready_timeout }} seconds.
+          Give up!
+      when:
+        - registry_enabled
+        - registry_pod.resources[0].status.phase != 'Running'
 ...

--- a/vars.yml.sample
+++ b/vars.yml.sample
@@ -433,7 +433,7 @@ ceph_rgw_port: "{{ radosgw_frontend_port }}"
 
 # burrito.ceph-csi role variables
 ceph_pool: "{{ kube_pool.name }}"
-cephcsi_version: "v3.10.1"
+cephcsi_version: "v3.14.2"
 # common csi driver versions
 csi_attacher_version: "v4.9.0"
 csi_node_driver_registrar_version: "v2.14.0"


### PR DESCRIPTION
- feature(storage): upgrade ceph-csi from v3.10.1 to v3.14.2
- move set auth_client_required to cephx task from burrito.ceph-csi to burrito.ceph
- storage(ceph): add --image parameter in ceph purge tasks
- storage: move registry pod check task from burrito.ceph-csi to storage.yml playbook
- update netapp_patch.yml since the deployment and daemonset names of trident are changed
- checklist: put no_log: true in powerstore check task
